### PR TITLE
wireguardif: route decrypted RX through netif->input, not ip_input() (fixes pbuf double-free crash)

### DIFF
--- a/components/microlink/components/wireguard_lwip/src/wireguardif.c
+++ b/components/microlink/components/wireguard_lwip/src/wireguardif.c
@@ -539,9 +539,14 @@ static void wireguardif_process_data_message(struct wireguard_device *device, st
 								if (dest_ok) {
 									// Send packet to be processed by LWIP
 									WG_DEBUG("[WG_RX_IP] Passing %u bytes to IP layer\n", (unsigned)pbuf->tot_len);
-									ip_input(pbuf, device->netif);
-									// pbuf is owned by IP layer now
-									pbuf = NULL;
+									// Enter the lwIP core ONLY from the tcpip_thread. netif->input is
+									// tcpip_input (set in ml_wg_mgr): posting the packet defers ip_input
+									// to the tcpip_thread. Calling ip_input() directly here runs on the
+									// wg_mgr task and races the tcpip_thread's WiFi TCP processing ->
+									// unsynchronized pbuf/PCB access -> double-free crash (pbuf.c:753).
+									if (device->netif->input(pbuf, device->netif) == ERR_OK) {
+										pbuf = NULL;  // ownership handed to the tcpip_thread queue
+									}  // else: still ours -> freed by pbuf_free() at the end of this block
 								} else {
 									WG_DEBUG("[WG_RX_IP] DROPPED: dest_ok=false\n");
 								}


### PR DESCRIPTION
Fixes #17.

The decrypted-RX path called `ip_input()` directly on the caller's task, entering the lwIP core concurrently with `tcpip_thread`. Under sustained TCP traffic through the tunnel this double-frees a sent-segment pbuf (`pbuf_free: p->ref > 0` assert) and reboots the device mid-transfer.

`ml_wg_mgr` already sets `netif->input = tcpip_input` — the integration intends all input serialized through the tcpip mailbox; the direct `ip_input()` call bypassed that. This change hands the decrypted pbuf to `netif->input` so the lwIP core is only ever entered from `tcpip_thread`.

**Verified on hardware** (ESP32-S3 N16R8, ESP-IDF v5.3): a TCP proxy on the tailnet IP relaying ~600 KB streams crashed the board mid-transfer every time before this change; after it, jobs run to completion, and the node survived overnight idle plus a WAN modem restart. CRLF line endings preserved.