### PR TITLE
Support custom (non-Tailscale) control planes end-to-end: TLS control, streaming map-poll, DERP

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,25 @@ MicroLink supports custom coordination servers like [Headscale](https://github.c
 
 **Configuration:** Set the control plane host via the HTTP config server web UI (Device Settings → Control Plane Host) or programmatically via `ctrl_host` in the config struct.
 
+**Build-time configuration:** For pre-provisioned firmware, or when the HTTP config server is disabled, the control plane can also be set at build time:
+
+```ini
+# sdkconfig.defaults
+CONFIG_ML_CTRL_HOST="headscale.example.com"
+
+# Control planes that only expose an HTTPS listener (e.g. Headscale behind
+# a reverse proxy / load balancer on port 443) cannot accept MicroLink's
+# default plain-TCP port-80 transport. This wraps the ts2021 Noise
+# handshake in TLS on port 443 instead. The server certificate is not
+# verified; the control plane is authenticated by the pinned Noise public
+# key below (same trust model as the plain port-80 transport).
+CONFIG_ML_CTRL_TLS=y
+
+# The control plane's Noise public key, from
+# https://<host>/key?v=88 → "publicKey":"mkey:<hex>" (64-char hex)
+CONFIG_ML_CTRL_NOISE_PUBKEY_HEX="..."
+```
+
 **Server key:** MicroLink automatically fetches the server's Noise public key from the `/key` endpoint via HTTPS. No manual key configuration required.
 
 **Notes:**

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ V2 uses fully dynamic DERP discovery — no manual region configuration needed. 
 
 MicroLink supports custom coordination servers like [Headscale](https://github.com/juanfont/headscale) and [Ionscale](https://github.com/jsiebens/ionscale). This allows you to run your own private Tailscale-compatible control plane.
 
-**Configuration:** Set the control plane host via the HTTP config server web UI (Device Settings → Control Plane Host) or programmatically via `ctrl_host` in the config struct.
+**Configuration:** Set the control plane host via the HTTP config server web UI (Device Settings → Control Plane Host) or programmatically via `ctrl_host` in the config struct. The server's Noise public key can likewise be supplied at runtime via `ctrl_noise_pubkey` (32 bytes) — fetch it from `https://<host>/key?v=88` (`"publicKey":"mkey:<hex>"`) during provisioning, or pin it at build time (below).
 
 **Build-time configuration:** For pre-provisioned firmware, or when the HTTP config server is disabled, the control plane can also be set at build time:
 

--- a/components/microlink/CMakeLists.txt
+++ b/components/microlink/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SRCS
     "src/microlink.c"
     "src/ml_coord.c"
+    "src/ml_coord_tls.c"
     "src/ml_derp.c"
     "src/ml_net_io.c"
     "src/ml_wg_mgr.c"

--- a/components/microlink/Kconfig
+++ b/components/microlink/Kconfig
@@ -287,6 +287,37 @@ menu "MicroLink V2 Configuration"
 
     endmenu
 
+    menu "Control Plane"
+
+        config ML_CTRL_HOST
+            string "Control plane hostname"
+            default "controlplane.tailscale.com"
+            help
+                Coordination server hostname. Set to a Headscale-compatible
+                host (e.g. Lolipop Zero Trust Link controller) to use a
+                custom control plane. NVS runtime override still wins.
+
+        config ML_CTRL_TLS
+            bool "Connect to control plane over TLS (port 443)"
+            default n
+            help
+                Wrap the ts2021 Noise handshake in TLS on port 443 instead
+                of plain TCP on port 80. Required for control planes that
+                only expose an HTTPS listener (e.g. Headscale behind an LB).
+                The server certificate is NOT verified; the control plane is
+                authenticated by the pinned Noise public key instead, same
+                trust model as Tailscale's plain port-80 transport.
+
+        config ML_CTRL_NOISE_PUBKEY_HEX
+            string "Control plane Noise public key (hex)"
+            default ""
+            help
+                64-char hex of the control plane's Noise (machine) public key,
+                from https://<control-host>/key?v=88 → "publicKey":"mkey:<hex>".
+                Empty = use the built-in Tailscale key.
+
+    endmenu
+
     menu "HTTP Config Server"
 
         config ML_ENABLE_CONFIG_HTTPD

--- a/components/microlink/components/wireguard_lwip/src/wireguard-platform-esp32.c
+++ b/components/microlink/components/wireguard_lwip/src/wireguard-platform-esp32.c
@@ -5,7 +5,6 @@
 
 #include "wireguard-platform.h"
 #include "esp_random.h"
-#include "esp_timer.h"
 #include "lwip/sys.h"
 #include <string.h>
 #include <sys/time.h>

--- a/components/microlink/components/wireguard_lwip/src/wireguard-platform-esp32.c
+++ b/components/microlink/components/wireguard_lwip/src/wireguard-platform-esp32.c
@@ -8,6 +8,7 @@
 #include "esp_timer.h"
 #include "lwip/sys.h"
 #include <string.h>
+#include <sys/time.h>
 
 /* ============================================================================
  * Time Functions
@@ -19,18 +20,19 @@ uint32_t wireguard_sys_now() {
 }
 
 void wireguard_tai64n_now(uint8_t *output) {
-    // TAI64N format: 8 bytes seconds + 4 bytes nanoseconds
-    // For simplicity, use Unix epoch time
-    uint64_t now_us = esp_timer_get_time();
-    uint64_t seconds = now_us / 1000000ULL;
-    uint32_t nanoseconds = (now_us % 1000000ULL) * 1000;
-
-    // Log raw uptime before TAI offset (only every ~5s to avoid spam)
-    static uint64_t last_log_s = 0;
-    if (seconds - last_log_s >= 5) {
-        printf("[TAI64N] uptime=%llu s, nano=%lu\n", (unsigned long long)seconds, (unsigned long)nanoseconds);
-        last_log_s = seconds;
-    }
+    // TAI64N format: 8 bytes seconds + 4 bytes nanoseconds.
+    //
+    // This must be wall-clock time, not uptime. A peer keeps the greatest
+    // timestamp it has seen from us and rejects any handshake initiation whose
+    // timestamp is not greater (replay protection, WireGuard spec 5.1). With
+    // uptime, every reboot restarts the counter near zero, so the peer rejects
+    // us with "handshake replay" until our uptime passes the previous session's
+    // — a device that ran for hours cannot reconnect at all after a reboot.
+    // The system clock is expected to be set (e.g. by SNTP) before connecting.
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    uint64_t seconds = (uint64_t)tv.tv_sec;
+    uint32_t nanoseconds = (uint32_t)tv.tv_usec * 1000;
 
     // TAI64 starts at 1970-01-01 00:00:10 TAI (Unix epoch + 10 seconds)
     // Add TAI offset: 2^62 + Unix time

--- a/components/microlink/components/wireguard_lwip/src/wireguardif.c
+++ b/components/microlink/components/wireguard_lwip/src/wireguardif.c
@@ -537,10 +537,21 @@ static void wireguardif_process_data_message(struct wireguard_device *device, st
 
 								// 5. If the plaintext packet has not been dropped, it is inserted into the receive queue of the wg0 interface.
 								if (dest_ok) {
-									// Send packet to be processed by LWIP
+									// Deliver through netif->input (the host sets this to
+									// tcpip_input) so TCP runs on the TCPIP thread, serialized
+									// with app-side socket operations. Calling ip_input()
+									// directly here processes TCP on the WireGuard rx task
+									// concurrently with app sockets and corrupts lwIP PCB state
+									// (the unacked segment list), which crashes in tcp_output.
 									WG_DEBUG("[WG_RX_IP] Passing %u bytes to IP layer\n", (unsigned)pbuf->tot_len);
-									ip_input(pbuf, device->netif);
-									// pbuf is owned by IP layer now
+									if (device->netif->input != NULL) {
+										if (device->netif->input(pbuf, device->netif) != ERR_OK) {
+											pbuf_free(pbuf);
+										}
+									} else {
+										ip_input(pbuf, device->netif);
+									}
+									// pbuf is owned by the IP/TCPIP layer now
 									pbuf = NULL;
 								} else {
 									WG_DEBUG("[WG_RX_IP] DROPPED: dest_ok=false\n");

--- a/components/microlink/include/microlink.h
+++ b/components/microlink/include/microlink.h
@@ -45,6 +45,15 @@ typedef struct {
     uint32_t disco_heartbeat_ms;    /* DISCO keepalive interval (default: 3000) */
     uint32_t stun_interval_ms;      /* STUN re-probe interval (default: 23000) */
     uint32_t ctrl_watchdog_ms;      /* Control plane watchdog timeout (default: 120000) */
+
+    /* Custom control plane (Headscale / Ionscale). NULL = use the
+     * CONFIG_ML_CTRL_HOST / CONFIG_ML_CTRL_NOISE_PUBKEY_HEX build-time
+     * values, falling back to Tailscale's. The NVS web-UI override, if
+     * present, still wins over both. */
+    const char *ctrl_host;          /* Coordination server hostname */
+    const uint8_t *ctrl_noise_pubkey; /* Server Noise public key (32 bytes),
+                                        e.g. fetched from https://<host>/key?v=88
+                                        at provisioning time */
 } microlink_config_t;
 
 /* Peer info (read-only snapshot) */

--- a/components/microlink/include/microlink.h
+++ b/components/microlink/include/microlink.h
@@ -84,6 +84,12 @@ typedef enum {
     ML_STATE_CONNECTED,
     ML_STATE_RECONNECTING,
     ML_STATE_ERROR,
+    /* Registration was rejected by the control plane (expired/revoked auth
+     * key, or the node awaits authorization). The stack keeps retrying at
+     * maximum backoff, but recovery normally needs a new auth key — hosts
+     * should surface this to the user as their equivalent of a "re-login"
+     * prompt (headless devices have no UI to notice it otherwise). */
+    ML_STATE_AUTH_FAILED,
 } microlink_state_t;
 
 /* Callback types */

--- a/components/microlink/include/microlink.h
+++ b/components/microlink/include/microlink.h
@@ -54,6 +54,16 @@ typedef struct {
     const uint8_t *ctrl_noise_pubkey; /* Server Noise public key (32 bytes),
                                         e.g. fetched from https://<host>/key?v=88
                                         at provisioning time */
+
+    /* Some headscale-based controllers never respond to the initial
+     * Stream=false MapRequest (e.g. ZTL: 60s of zero bytes -> Empty
+     * MapResponse -> reconnect loop). The official Tailscale client uses a
+     * single Stream=true streaming poll from the start, and the first stream
+     * message carries the full netmap (Peers + DERPMap).
+     * Setting this to true switches to that scheme (start with Stream=true /
+     * OmitPeers=false and take Peers + DERPMap from the first MapResponse).
+     * false (default) keeps the existing Stream=false one-shot fetch. */
+    bool streaming_map_fetch;
 } microlink_config_t;
 
 /* Peer info (read-only snapshot) */

--- a/components/microlink/include/microlink_internal.h
+++ b/components/microlink/include/microlink_internal.h
@@ -79,7 +79,11 @@ extern "C" {
 #define ML_DERP_PORT            443
 
 /* Tailscale control plane */
+#ifdef CONFIG_ML_CTRL_HOST
+#define ML_CTRL_HOST            CONFIG_ML_CTRL_HOST
+#else
 #define ML_CTRL_HOST            "controlplane.tailscale.com"
+#endif
 #define ML_CTRL_PORT            443
 #define ML_CTRL_PROTOCOL_VER    131
 
@@ -331,6 +335,19 @@ typedef struct {
 } ml_derp_conn_t;
 
 /* ============================================================================
+ * Control Plane TLS State (CONFIG_ML_CTRL_TLS)
+ * ========================================================================== */
+
+typedef struct {
+    mbedtls_ssl_context ssl;        /* Owned exclusively by coord task */
+    mbedtls_ssl_config ssl_conf;
+    mbedtls_entropy_context entropy;
+    mbedtls_ctr_drbg_context ctr_drbg;
+    int sockfd;                     /* Copy of coord_sock for the BIO callbacks */
+    bool active;                    /* TLS session established */
+} ml_coord_tls_t;
+
+/* ============================================================================
  * Main Context
  * ========================================================================== */
 
@@ -379,6 +396,9 @@ struct microlink_s {
 
     /* Coordination socket (owned exclusively by coord task) */
     int coord_sock;
+#ifdef CONFIG_ML_CTRL_TLS
+    ml_coord_tls_t coord_tls;
+#endif
     uint32_t h2_next_stream_id;         /* Next H2 stream ID for endpoint updates (odd, starts at 7) */
 
     /* WireGuard netif (owned exclusively by wg_mgr task) */
@@ -487,6 +507,15 @@ bool ml_stun_parse_response(const uint8_t *data, size_t len,
                              uint32_t *out_ip, uint16_t *out_port);
 bool ml_stun_parse_response_ipv6(const uint8_t *data, size_t len,
                                   uint8_t *out_ip6, uint16_t *out_port);
+
+/* ml_coord_tls.c (CONFIG_ML_CTRL_TLS) */
+#ifdef CONFIG_ML_CTRL_TLS
+int ml_coord_tls_handshake(microlink_t *ml, const char *hostname);
+int ml_coord_tls_send(microlink_t *ml, const uint8_t *data, size_t len);
+int ml_coord_tls_recv(microlink_t *ml, uint8_t *buf, size_t len);
+size_t ml_coord_tls_pending(microlink_t *ml);
+void ml_coord_tls_free(microlink_t *ml);
+#endif
 
 /* ml_noise.c */
 void ml_noise_init(ml_noise_state_t *state,

--- a/components/microlink/include/microlink_internal.h
+++ b/components/microlink/include/microlink_internal.h
@@ -462,8 +462,15 @@ struct microlink_s {
     char nvs_device_name[48];
 
     /* Control plane host override (empty = use ML_CTRL_HOST default).
-     * Set from NVS at boot for Headscale/Ionscale/custom coordinators. */
+     * Set from config struct or NVS at boot for Headscale/Ionscale/custom
+     * coordinators. */
     char ctrl_host[64];
+
+    /* Control plane Noise public key override (from config struct;
+     * ctrl_noise_pubkey_set false = use CONFIG_ML_CTRL_NOISE_PUBKEY_HEX
+     * or the built-in Tailscale key) */
+    uint8_t ctrl_noise_pubkey[32];
+    bool ctrl_noise_pubkey_set;
 
     /* Debug flags (bitmask from NVS, checked at runtime for verbose logging) */
     uint8_t debug_flags;  /* bit 0: DISCO, bit 1: WG, bit 2: DERP, bit 3: coord */

--- a/components/microlink/src/microlink.c
+++ b/components/microlink/src/microlink.c
@@ -177,6 +177,16 @@ microlink_t *microlink_init(const microlink_config_t *config) {
     if (ml->config.max_peers > ML_MAX_PEERS) ml->config.max_peers = ML_MAX_PEERS;
     ml->config.enable_derp = true;  /* Always need DERP for relay */
 
+    /* Custom control plane from config struct (NVS override below still wins) */
+    if (config->ctrl_host && config->ctrl_host[0]) {
+        strncpy(ml->ctrl_host, config->ctrl_host, sizeof(ml->ctrl_host) - 1);
+        ESP_LOGI(TAG, "Control plane from config: %s", ml->ctrl_host);
+    }
+    if (config->ctrl_noise_pubkey) {
+        memcpy(ml->ctrl_noise_pubkey, config->ctrl_noise_pubkey, 32);
+        ml->ctrl_noise_pubkey_set = true;
+    }
+
     ml->state = ML_STATE_IDLE;
     ml->coord_sock = -1;
     ml->disco_sock4 = -1;

--- a/components/microlink/src/ml_coord.c
+++ b/components/microlink/src/ml_coord.c
@@ -778,7 +778,7 @@ static int do_register(microlink_t *ml, ml_noise_state_t *noise) {
     cJSON *hostinfo = cJSON_CreateObject();
     const char *dev_name = (ml->config.device_name && ml->config.device_name[0]) ? ml->config.device_name : microlink_default_device_name();
     cJSON_AddStringToObject(hostinfo, "Hostname", dev_name);
-    cJSON_AddStringToObject(hostinfo, "OS", "linux");
+    cJSON_AddStringToObject(hostinfo, "OS", "esp32");
     cJSON_AddStringToObject(hostinfo, "OSVersion", "ESP-IDF");
     cJSON_AddStringToObject(hostinfo, "GoArch", "arm");
 
@@ -1569,7 +1569,7 @@ static int do_fetch_peers(microlink_t *ml, ml_noise_state_t *noise) {
     cJSON *hostinfo = cJSON_CreateObject();
     const char *dev_name = (ml->config.device_name && ml->config.device_name[0]) ? ml->config.device_name : microlink_default_device_name();
     cJSON_AddStringToObject(hostinfo, "Hostname", dev_name);
-    cJSON_AddStringToObject(hostinfo, "OS", "linux");
+    cJSON_AddStringToObject(hostinfo, "OS", "esp32");
     cJSON_AddStringToObject(hostinfo, "OSVersion", "ESP-IDF");
     cJSON_AddStringToObject(hostinfo, "GoArch", "arm");
     cJSON_AddItemToObject(root, "Hostinfo", hostinfo);
@@ -1896,7 +1896,7 @@ static int do_start_long_poll(microlink_t *ml, ml_noise_state_t *noise, bool omi
     if (hostinfo) {
         const char *dev_name = (ml->config.device_name && ml->config.device_name[0]) ? ml->config.device_name : microlink_default_device_name();
         cJSON_AddStringToObject(hostinfo, "Hostname", dev_name);
-        cJSON_AddStringToObject(hostinfo, "OS", "linux");
+        cJSON_AddStringToObject(hostinfo, "OS", "esp32");
         cJSON_AddStringToObject(hostinfo, "OSVersion", "ESP-IDF");
         cJSON_AddStringToObject(hostinfo, "GoArch", "arm");
         cJSON_AddItemToObject(root, "Hostinfo", hostinfo);
@@ -2216,7 +2216,7 @@ static int do_send_endpoint_update(microlink_t *ml, ml_noise_state_t *noise) {
     if (hostinfo) {
         const char *dev_name = (ml->config.device_name && ml->config.device_name[0]) ? ml->config.device_name : microlink_default_device_name();
         cJSON_AddStringToObject(hostinfo, "Hostname", dev_name);
-        cJSON_AddStringToObject(hostinfo, "OS", "linux");
+        cJSON_AddStringToObject(hostinfo, "OS", "esp32");
         cJSON_AddStringToObject(hostinfo, "OSVersion", "ESP-IDF");
         cJSON_AddStringToObject(hostinfo, "GoArch", "arm");
         cJSON_AddItemToObject(root, "Hostinfo", hostinfo);

--- a/components/microlink/src/ml_coord.c
+++ b/components/microlink/src/ml_coord.c
@@ -334,13 +334,16 @@ static int do_noise_handshake(microlink_t *ml, ml_noise_state_t *noise) {
     int64_t t_noise_start = esp_timer_get_time();
 
     /* Initialize Noise state with our machine key and the control plane's
-     * server key. CONFIG_ML_CTRL_NOISE_PUBKEY_HEX overrides the built-in
-     * Tailscale key for Headscale-compatible control planes (value comes
-     * from https://<control-host>/key?v=88 → "publicKey":"mkey:<hex>"). */
+     * server key. Priority: config-struct key (runtime, e.g. fetched from
+     * https://<control-host>/key?v=88 at provisioning time) >
+     * CONFIG_ML_CTRL_NOISE_PUBKEY_HEX (build-time) > built-in Tailscale key. */
     const uint8_t *server_key = NULL;
+    if (ml->ctrl_noise_pubkey_set) {
+        server_key = ml->ctrl_noise_pubkey;
+    }
 #ifdef CONFIG_ML_CTRL_NOISE_PUBKEY_HEX
     static uint8_t custom_server_key[32];
-    if (CONFIG_ML_CTRL_NOISE_PUBKEY_HEX[0] != '\0') {
+    if (!server_key && CONFIG_ML_CTRL_NOISE_PUBKEY_HEX[0] != '\0') {
         if (hex_to_bytes(CONFIG_ML_CTRL_NOISE_PUBKEY_HEX, custom_server_key, 32) == 32) {
             server_key = custom_server_key;
         } else {

--- a/components/microlink/src/ml_coord.c
+++ b/components/microlink/src/ml_coord.c
@@ -2924,8 +2924,11 @@ void ml_coord_task(void *arg) {
 
                 /* CONNECTED や AUTH_FAILED と同様にホストへ通知する (画面等の
                  * 状態表示が接続中のまま残るのを防ぐ)。バックオフごとに再入する
-                 * ため、遷移した最初の1回だけ発火する */
-                if (ml->state != ML_STATE_RECONNECTING) {
+                 * ため遷移した最初の1回だけ発火し、AUTH_FAILED 中は上書きしない
+                 * (キー失効は「人の操作が必要」な状態で、再試行のたびに
+                 * RECONNECTING へ落とすとホストの再ログイン表示が消えてしまう) */
+                if (ml->state != ML_STATE_RECONNECTING &&
+                    ml->state != ML_STATE_AUTH_FAILED) {
                     ml->state = ML_STATE_RECONNECTING;
                     if (ml->state_cb) {
                         ml->state_cb(ml, ML_STATE_RECONNECTING, ml->state_cb_data);

--- a/components/microlink/src/ml_coord.c
+++ b/components/microlink/src/ml_coord.c
@@ -751,6 +751,9 @@ static int do_h2_preface(microlink_t *ml, ml_noise_state_t *noise) {
  * State: REGISTER - Send RegisterRequest, parse RegisterResponse
  * ========================================================================== */
 
+/* do_register: the control plane rejected our auth (vs. -1 = I/O error) */
+#define ML_REG_AUTH_FAILED (-2)
+
 static int do_register(microlink_t *ml, ml_noise_state_t *noise) {
     int64_t t_reg_start = esp_timer_get_time();
 
@@ -1012,6 +1015,25 @@ static int do_register(microlink_t *ml, ml_noise_state_t *noise) {
     }
     parse_start[parse_len] = saved;
     free(resp_buf);
+
+    /* The control plane reports auth problems in-band: a non-empty Error or
+     * MachineAuthorized=false means the auth key was rejected (expired,
+     * revoked, or pending approval). Without this check a rejected
+     * registration looks like success and the client spins in the reconnect
+     * loop with no way for the host app to tell the user. Return
+     * ML_REG_AUTH_FAILED so the coordinator can raise ML_STATE_AUTH_FAILED. */
+    cJSON *reg_err = cJSON_GetObjectItem(resp_json, "Error");
+    if (reg_err && cJSON_IsString(reg_err) && reg_err->valuestring[0]) {
+        ESP_LOGE(TAG, "Registration rejected by control plane: %s", reg_err->valuestring);
+        cJSON_Delete(resp_json);
+        return ML_REG_AUTH_FAILED;
+    }
+    cJSON *authorized = cJSON_GetObjectItem(resp_json, "MachineAuthorized");
+    if (authorized && cJSON_IsFalse(authorized)) {
+        ESP_LOGE(TAG, "Registration not authorized by control plane");
+        cJSON_Delete(resp_json);
+        return ML_REG_AUTH_FAILED;
+    }
 
     /* Extract our VPN IP from Node.Addresses */
     cJSON *node = cJSON_GetObjectItem(resp_json, "Node");
@@ -2565,11 +2587,25 @@ void ml_coord_task(void *arg) {
 
         case COORD_REGISTER:
             ESP_LOGI(TAG, "Registering...");
-            if (do_register(ml, &noise) < 0) {
-                ESP_LOGE(TAG, "Registration failed");
-                coord_close_conn(ml);
-                state = COORD_RECONNECTING;
-                break;
+            {
+                int reg_rc = do_register(ml, &noise);
+                if (reg_rc < 0) {
+                    ESP_LOGE(TAG, "Registration failed");
+                    if (reg_rc == ML_REG_AUTH_FAILED) {
+                        /* Not transient: retrying with the same key will keep
+                         * failing. Notify the host (its "re-login" prompt) and
+                         * jump to maximum backoff — the loop keeps running in
+                         * case the key is re-enabled server-side. */
+                        ml->state = ML_STATE_AUTH_FAILED;
+                        if (ml->state_cb) {
+                            ml->state_cb(ml, ML_STATE_AUTH_FAILED, ml->state_cb_data);
+                        }
+                        reconnect_attempts = 5;
+                    }
+                    coord_close_conn(ml);
+                    state = COORD_RECONNECTING;
+                    break;
+                }
             }
             state = COORD_FETCH_PEERS;
             break;
@@ -2825,6 +2861,10 @@ void ml_coord_task(void *arg) {
                                 break;
                             } else {
                                 ESP_LOGE(TAG, "Key expired but no auth_key — manual re-provisioning needed!");
+                                ml->state = ML_STATE_AUTH_FAILED;
+                                if (ml->state_cb) {
+                                    ml->state_cb(ml, ML_STATE_AUTH_FAILED, ml->state_cb_data);
+                                }
                             }
                         }
                         /* Warn 1 hour before expiry (rough uptime-based check) */

--- a/components/microlink/src/ml_coord.c
+++ b/components/microlink/src/ml_coord.c
@@ -2922,11 +2922,13 @@ void ml_coord_task(void *arg) {
                 ESP_LOGI(TAG, "Reconnecting in %lu ms (attempt %d)",
                          (unsigned long)backoff_ms, reconnect_attempts + 1);
 
-                /* CONNECTED や AUTH_FAILED と同様にホストへ通知する (画面等の
-                 * 状態表示が接続中のまま残るのを防ぐ)。バックオフごとに再入する
-                 * ため遷移した最初の1回だけ発火し、AUTH_FAILED 中は上書きしない
-                 * (キー失効は「人の操作が必要」な状態で、再試行のたびに
-                 * RECONNECTING へ落とすとホストの再ログイン表示が消えてしまう) */
+                /* Notify the host like CONNECTED and AUTH_FAILED do, so a
+                 * status display does not keep showing "connected" through an
+                 * outage. The loop re-enters this state on every backoff
+                 * cycle, so fire only on the transition — and never downgrade
+                 * AUTH_FAILED, which requires human action: overwriting it
+                 * with RECONNECTING on each retry would clear the host's
+                 * re-login prompt. */
                 if (ml->state != ML_STATE_RECONNECTING &&
                     ml->state != ML_STATE_AUTH_FAILED) {
                     ml->state = ML_STATE_RECONNECTING;

--- a/components/microlink/src/ml_coord.c
+++ b/components/microlink/src/ml_coord.c
@@ -2922,7 +2922,15 @@ void ml_coord_task(void *arg) {
                 ESP_LOGI(TAG, "Reconnecting in %lu ms (attempt %d)",
                          (unsigned long)backoff_ms, reconnect_attempts + 1);
 
-                ml->state = ML_STATE_RECONNECTING;
+                /* CONNECTED や AUTH_FAILED と同様にホストへ通知する (画面等の
+                 * 状態表示が接続中のまま残るのを防ぐ)。バックオフごとに再入する
+                 * ため、遷移した最初の1回だけ発火する */
+                if (ml->state != ML_STATE_RECONNECTING) {
+                    ml->state = ML_STATE_RECONNECTING;
+                    if (ml->state_cb) {
+                        ml->state_cb(ml, ML_STATE_RECONNECTING, ml->state_cb_data);
+                    }
+                }
 
                 /* Wait on command queue with backoff timeout (interruptible!) */
                 ml_coord_cmd_t wake_cmd;

--- a/components/microlink/src/ml_coord.c
+++ b/components/microlink/src/ml_coord.c
@@ -943,6 +943,7 @@ static int do_register(microlink_t *ml, ml_noise_state_t *noise) {
 
         fpos += f_len;
     }
+    (void)got_end_stream;  /* Currently unused for completion detection (suppress -Wunused-but-set-variable) */
     free(h2_resp);
 
     /* Send connection-level WINDOW_UPDATE for RegisterResponse.
@@ -975,6 +976,7 @@ static int do_register(microlink_t *ml, ml_noise_state_t *noise) {
         hexbuf[dump * 3] = '\0';
         ESP_LOGI(TAG, "RegisterResponse first %d bytes (hex): %s", dump, hexbuf);
     }
+
 
     /* Find start of JSON - skip any binary prefix */
     char *parse_start = (char *)json_data;
@@ -1364,6 +1366,180 @@ static int add_endpoints_to_json(microlink_t *ml, cJSON *root) {
     return count;
 }
 
+/* Ingest the self-node info (VPN IP / HomeDERP / KeyExpiry / Expired) from
+ * a MapResponse. Shared parser called from both paths — the Stream=false
+ * one-shot fetch and the streaming_map_fetch initial netmap (extracted from
+ * do_fetch_peers). */
+static void parse_self_node_from_map(microlink_t *ml, cJSON *map_json) {
+    cJSON *node = cJSON_GetObjectItem(map_json, "Node");
+    if (!node) return;
+
+    /* Extract VPN IP if not already set */
+    if (ml->vpn_ip == 0) {
+        cJSON *addresses = cJSON_GetObjectItem(node, "Addresses");
+        if (addresses && cJSON_GetArraySize(addresses) > 0) {
+            const char *addr = cJSON_GetArrayItem(addresses, 0)->valuestring;
+            if (addr) {
+                unsigned a, b, c, d;
+                if (sscanf(addr, "%u.%u.%u.%u", &a, &b, &c, &d) == 4) {
+                    ml->vpn_ip = (a << 24) | (b << 16) | (c << 8) | d;
+                    char ip_str[16];
+                    microlink_ip_to_str(ml->vpn_ip, ip_str);
+                    ESP_LOGI(TAG, "Our VPN IP: %s", ip_str);
+                }
+            }
+        }
+    }
+    /* Parse self-node DERP region — try modern HomeDERP (int) first,
+     * then fall back to legacy DERP string (format: "127.3.3.40:REGION") */
+    cJSON *home_derp = cJSON_GetObjectItem(node, "HomeDERP");
+    if (home_derp && cJSON_IsNumber(home_derp) && home_derp->valueint > 0) {
+        ml->derp_home_region = (uint16_t)home_derp->valueint;
+        ESP_LOGI(TAG, "Home DERP region: %d (from server, HomeDERP)", ml->derp_home_region);
+    } else {
+        cJSON *self_derp = cJSON_GetObjectItem(node, "DERP");
+        if (self_derp && self_derp->valuestring) {
+            ESP_LOGI(TAG, "Self-Node DERP: %s", self_derp->valuestring);
+            const char *colon = strrchr(self_derp->valuestring, ':');
+            if (colon) {
+                int region = atoi(colon + 1);
+                if (region > 0) {
+                    ml->derp_home_region = (uint16_t)region;
+                    ESP_LOGI(TAG, "Home DERP region: %d (from server, legacy DERP)", region);
+                }
+            }
+        }
+    }
+    /* Fallback: if server didn't assign a DERP region, use our configured default */
+    if (ml->derp_home_region == 0) {
+        ml->derp_home_region = ML_DERP_REGION;
+        ESP_LOGI(TAG, "Home DERP region: %d (default)", ML_DERP_REGION);
+    }
+    cJSON *self_key = cJSON_GetObjectItem(node, "Key");
+    if (self_key && self_key->valuestring) {
+        ESP_LOGI(TAG, "Self-Node Key (server): %.40s...", self_key->valuestring);
+        char our_hex[65];
+        bytes_to_hex(ml->wg_public_key, 32, our_hex);
+        ESP_LOGI(TAG, "Our WG pubkey (local):  nodekey:%.32s...", our_hex);
+    }
+
+    /* Parse KeyExpiry (ISO 8601: "YYYY-MM-DDTHH:MM:SSZ") */
+    cJSON *key_expiry = cJSON_GetObjectItem(node, "KeyExpiry");
+    if (key_expiry && key_expiry->valuestring) {
+        int yr, mo, dy, hr, mn, sc;
+        if (sscanf(key_expiry->valuestring, "%d-%d-%dT%d:%d:%d",
+                   &yr, &mo, &dy, &hr, &mn, &sc) >= 6) {
+            /* Simple epoch calculation (approximate, no leap second) */
+            /* Days from year 1970 */
+            int64_t days = 0;
+            for (int y = 1970; y < yr; y++) {
+                days += (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) ? 366 : 365;
+            }
+            static const int mdays[] = {0,31,28,31,30,31,30,31,31,30,31,30,31};
+            for (int m = 1; m < mo; m++) {
+                days += mdays[m];
+                if (m == 2 && (yr % 4 == 0 && (yr % 100 != 0 || yr % 400 == 0))) days++;
+            }
+            days += dy - 1;
+            ml->key_expiry_epoch = days * 86400 + hr * 3600 + mn * 60 + sc;
+            ESP_LOGI(TAG, "Key expiry: %s (epoch: %lld)", key_expiry->valuestring,
+                     (long long)ml->key_expiry_epoch);
+        }
+    }
+
+    /* Check Expired flag */
+    cJSON *expired = cJSON_GetObjectItem(node, "Expired");
+    if (expired && cJSON_IsTrue(expired)) {
+        ml->key_expired = true;
+        ESP_LOGW(TAG, "Node key is EXPIRED — re-registration needed");
+    } else {
+        ml->key_expired = false;
+    }
+}
+
+/* Shared parser that ingests the DERPMap (all regions and nodes) from a
+ * MapResponse. Does nothing for MapResponses without a DERPMap (e.g.
+ * incremental updates). Called from both the Stream=false one-shot fetch
+ * and the streaming_map_fetch path (extracted from do_fetch_peers). */
+static void parse_derp_map_from_map(microlink_t *ml, cJSON *map_json) {
+    cJSON *derp_map = cJSON_GetObjectItem(map_json, "DERPMap");
+    if (!derp_map) return;
+    cJSON *regions = cJSON_GetObjectItem(derp_map, "Regions");
+    if (!regions) return;
+
+    ml->derp_region_count = 0;
+    cJSON *region_obj;
+    cJSON_ArrayForEach(region_obj, regions) {
+        if (ml->derp_region_count >= ML_MAX_DERP_REGIONS) break;
+        ml_derp_region_t *r = &ml->derp_regions[ml->derp_region_count];
+        memset(r, 0, sizeof(*r));
+
+        cJSON *rid = cJSON_GetObjectItem(region_obj, "RegionID");
+        if (rid) r->region_id = (uint16_t)rid->valuedouble;
+
+        cJSON *rcode = cJSON_GetObjectItem(region_obj, "RegionCode");
+        if (rcode && rcode->valuestring) {
+            strncpy(r->code, rcode->valuestring, sizeof(r->code) - 1);
+        }
+
+        cJSON *avoid = cJSON_GetObjectItem(region_obj, "Avoid");
+        if (avoid && cJSON_IsTrue(avoid)) r->avoid = true;
+
+        /* Parse nodes */
+        cJSON *nodes = cJSON_GetObjectItem(region_obj, "Nodes");
+        if (nodes) {
+            cJSON *node_obj;
+            cJSON_ArrayForEach(node_obj, nodes) {
+                if (r->node_count >= ML_MAX_DERP_NODES) break;
+                ml_derp_node_t *n = &r->nodes[r->node_count];
+                memset(n, 0, sizeof(*n));
+
+                cJSON *hn = cJSON_GetObjectItem(node_obj, "HostName");
+                if (hn && hn->valuestring) {
+                    strncpy(n->hostname, hn->valuestring, sizeof(n->hostname) - 1);
+                }
+
+                cJSON *ip4 = cJSON_GetObjectItem(node_obj, "IPv4");
+                if (ip4 && ip4->valuestring) {
+                    strncpy(n->ipv4, ip4->valuestring, sizeof(n->ipv4) - 1);
+                }
+
+                cJSON *ip6 = cJSON_GetObjectItem(node_obj, "IPv6");
+                if (ip6 && ip6->valuestring) {
+                    strncpy(n->ipv6, ip6->valuestring, sizeof(n->ipv6) - 1);
+                }
+
+                cJSON *sp = cJSON_GetObjectItem(node_obj, "STUNPort");
+                if (sp) n->stun_port = (uint16_t)sp->valuedouble;
+
+                cJSON *dp = cJSON_GetObjectItem(node_obj, "DERPPort");
+                if (dp) n->derp_port = (uint16_t)dp->valuedouble;
+
+                cJSON *so = cJSON_GetObjectItem(node_obj, "STUNOnly");
+                if (so && cJSON_IsTrue(so)) n->stun_only = true;
+
+                r->node_count++;
+            }
+        }
+
+        ESP_LOGI(TAG, "  DERP region %d (%s): %d nodes%s",
+                 r->region_id, r->code, r->node_count,
+                 r->avoid ? " [avoid]" : "");
+        for (int ni = 0; ni < r->node_count; ni++) {
+            ESP_LOGI(TAG, "    node: %s (v4=%s v6=%s stun=%d derp=%d%s)",
+                     r->nodes[ni].hostname,
+                     r->nodes[ni].ipv4[0] ? r->nodes[ni].ipv4 : "-",
+                     r->nodes[ni].ipv6[0] ? r->nodes[ni].ipv6 : "-",
+                     r->nodes[ni].stun_port ? r->nodes[ni].stun_port : 3478,
+                     r->nodes[ni].derp_port ? r->nodes[ni].derp_port : 443,
+                     r->nodes[ni].stun_only ? " stun-only" : "");
+        }
+
+        ml->derp_region_count++;
+    }
+    ESP_LOGI(TAG, "DERPMap: parsed %d regions", ml->derp_region_count);
+}
+
 static int do_fetch_peers(microlink_t *ml, ml_noise_state_t *noise) {
     int64_t t_map_start = esp_timer_get_time();
 
@@ -1671,174 +1847,13 @@ static int do_fetch_peers(microlink_t *ml, ml_noise_state_t *noise) {
     }
 
     /* Extract self-node info */
-    {
-        cJSON *node = cJSON_GetObjectItem(map_json, "Node");
-        if (node) {
-            /* Extract VPN IP if not already set */
-            if (ml->vpn_ip == 0) {
-                cJSON *addresses = cJSON_GetObjectItem(node, "Addresses");
-                if (addresses && cJSON_GetArraySize(addresses) > 0) {
-                    const char *addr = cJSON_GetArrayItem(addresses, 0)->valuestring;
-                    if (addr) {
-                        unsigned a, b, c, d;
-                        if (sscanf(addr, "%u.%u.%u.%u", &a, &b, &c, &d) == 4) {
-                            ml->vpn_ip = (a << 24) | (b << 16) | (c << 8) | d;
-                            char ip_str[16];
-                            microlink_ip_to_str(ml->vpn_ip, ip_str);
-                            ESP_LOGI(TAG, "Our VPN IP: %s", ip_str);
-                        }
-                    }
-                }
-            }
-            /* Parse self-node DERP region — try modern HomeDERP (int) first,
-             * then fall back to legacy DERP string (format: "127.3.3.40:REGION") */
-            cJSON *home_derp = cJSON_GetObjectItem(node, "HomeDERP");
-            if (home_derp && cJSON_IsNumber(home_derp) && home_derp->valueint > 0) {
-                ml->derp_home_region = (uint16_t)home_derp->valueint;
-                ESP_LOGI(TAG, "Home DERP region: %d (from server, HomeDERP)", ml->derp_home_region);
-            } else {
-                cJSON *self_derp = cJSON_GetObjectItem(node, "DERP");
-                if (self_derp && self_derp->valuestring) {
-                    ESP_LOGI(TAG, "Self-Node DERP: %s", self_derp->valuestring);
-                    const char *colon = strrchr(self_derp->valuestring, ':');
-                    if (colon) {
-                        int region = atoi(colon + 1);
-                        if (region > 0) {
-                            ml->derp_home_region = (uint16_t)region;
-                            ESP_LOGI(TAG, "Home DERP region: %d (from server, legacy DERP)", region);
-                        }
-                    }
-                }
-            }
-            /* Fallback: if server didn't assign a DERP region, use our configured default */
-            if (ml->derp_home_region == 0) {
-                ml->derp_home_region = ML_DERP_REGION;
-                ESP_LOGI(TAG, "Home DERP region: %d (default)", ML_DERP_REGION);
-            }
-            cJSON *self_key = cJSON_GetObjectItem(node, "Key");
-            if (self_key && self_key->valuestring) {
-                ESP_LOGI(TAG, "Self-Node Key (server): %.40s...", self_key->valuestring);
-                char our_hex[65];
-                bytes_to_hex(ml->wg_public_key, 32, our_hex);
-                ESP_LOGI(TAG, "Our WG pubkey (local):  nodekey:%.32s...", our_hex);
-            }
-
-            /* Parse KeyExpiry (ISO 8601: "YYYY-MM-DDTHH:MM:SSZ") */
-            cJSON *key_expiry = cJSON_GetObjectItem(node, "KeyExpiry");
-            if (key_expiry && key_expiry->valuestring) {
-                int yr, mo, dy, hr, mn, sc;
-                if (sscanf(key_expiry->valuestring, "%d-%d-%dT%d:%d:%d",
-                           &yr, &mo, &dy, &hr, &mn, &sc) >= 6) {
-                    /* Simple epoch calculation (approximate, no leap second) */
-                    /* Days from year 1970 */
-                    int64_t days = 0;
-                    for (int y = 1970; y < yr; y++) {
-                        days += (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) ? 366 : 365;
-                    }
-                    static const int mdays[] = {0,31,28,31,30,31,30,31,31,30,31,30,31};
-                    for (int m = 1; m < mo; m++) {
-                        days += mdays[m];
-                        if (m == 2 && (yr % 4 == 0 && (yr % 100 != 0 || yr % 400 == 0))) days++;
-                    }
-                    days += dy - 1;
-                    ml->key_expiry_epoch = days * 86400 + hr * 3600 + mn * 60 + sc;
-                    ESP_LOGI(TAG, "Key expiry: %s (epoch: %lld)", key_expiry->valuestring,
-                             (long long)ml->key_expiry_epoch);
-                }
-            }
-
-            /* Check Expired flag */
-            cJSON *expired = cJSON_GetObjectItem(node, "Expired");
-            if (expired && cJSON_IsTrue(expired)) {
-                ml->key_expired = true;
-                ESP_LOGW(TAG, "Node key is EXPIRED — re-registration needed");
-            } else {
-                ml->key_expired = false;
-            }
-        }
-    }
+    parse_self_node_from_map(ml, map_json);
 
     /* Parse peers */
     parse_peers_from_map_response(ml, map_json);
 
     /* Extract DERPMap if present — parse all regions and nodes */
-    cJSON *derp_map = cJSON_GetObjectItem(map_json, "DERPMap");
-    if (derp_map) {
-        cJSON *regions = cJSON_GetObjectItem(derp_map, "Regions");
-        if (regions) {
-            ml->derp_region_count = 0;
-            cJSON *region_obj;
-            cJSON_ArrayForEach(region_obj, regions) {
-                if (ml->derp_region_count >= ML_MAX_DERP_REGIONS) break;
-                ml_derp_region_t *r = &ml->derp_regions[ml->derp_region_count];
-                memset(r, 0, sizeof(*r));
-
-                cJSON *rid = cJSON_GetObjectItem(region_obj, "RegionID");
-                if (rid) r->region_id = (uint16_t)rid->valuedouble;
-
-                cJSON *rcode = cJSON_GetObjectItem(region_obj, "RegionCode");
-                if (rcode && rcode->valuestring) {
-                    strncpy(r->code, rcode->valuestring, sizeof(r->code) - 1);
-                }
-
-                cJSON *avoid = cJSON_GetObjectItem(region_obj, "Avoid");
-                if (avoid && cJSON_IsTrue(avoid)) r->avoid = true;
-
-                /* Parse nodes */
-                cJSON *nodes = cJSON_GetObjectItem(region_obj, "Nodes");
-                if (nodes) {
-                    cJSON *node_obj;
-                    cJSON_ArrayForEach(node_obj, nodes) {
-                        if (r->node_count >= ML_MAX_DERP_NODES) break;
-                        ml_derp_node_t *n = &r->nodes[r->node_count];
-                        memset(n, 0, sizeof(*n));
-
-                        cJSON *hn = cJSON_GetObjectItem(node_obj, "HostName");
-                        if (hn && hn->valuestring) {
-                            strncpy(n->hostname, hn->valuestring, sizeof(n->hostname) - 1);
-                        }
-
-                        cJSON *ip4 = cJSON_GetObjectItem(node_obj, "IPv4");
-                        if (ip4 && ip4->valuestring) {
-                            strncpy(n->ipv4, ip4->valuestring, sizeof(n->ipv4) - 1);
-                        }
-
-                        cJSON *ip6 = cJSON_GetObjectItem(node_obj, "IPv6");
-                        if (ip6 && ip6->valuestring) {
-                            strncpy(n->ipv6, ip6->valuestring, sizeof(n->ipv6) - 1);
-                        }
-
-                        cJSON *sp = cJSON_GetObjectItem(node_obj, "STUNPort");
-                        if (sp) n->stun_port = (uint16_t)sp->valuedouble;
-
-                        cJSON *dp = cJSON_GetObjectItem(node_obj, "DERPPort");
-                        if (dp) n->derp_port = (uint16_t)dp->valuedouble;
-
-                        cJSON *so = cJSON_GetObjectItem(node_obj, "STUNOnly");
-                        if (so && cJSON_IsTrue(so)) n->stun_only = true;
-
-                        r->node_count++;
-                    }
-                }
-
-                ESP_LOGI(TAG, "  DERP region %d (%s): %d nodes%s",
-                         r->region_id, r->code, r->node_count,
-                         r->avoid ? " [avoid]" : "");
-                for (int ni = 0; ni < r->node_count; ni++) {
-                    ESP_LOGI(TAG, "    node: %s (v4=%s v6=%s stun=%d derp=%d%s)",
-                             r->nodes[ni].hostname,
-                             r->nodes[ni].ipv4[0] ? r->nodes[ni].ipv4 : "-",
-                             r->nodes[ni].ipv6[0] ? r->nodes[ni].ipv6 : "-",
-                             r->nodes[ni].stun_port ? r->nodes[ni].stun_port : 3478,
-                             r->nodes[ni].derp_port ? r->nodes[ni].derp_port : 443,
-                             r->nodes[ni].stun_only ? " stun-only" : "");
-                }
-
-                ml->derp_region_count++;
-            }
-            ESP_LOGI(TAG, "DERPMap: parsed %d regions", ml->derp_region_count);
-        }
-    }
+    parse_derp_map_from_map(ml, map_json);
 
     cJSON_Delete(map_json);
     free(resp_buf);
@@ -1856,8 +1871,11 @@ static int do_fetch_peers(microlink_t *ml, ml_noise_state_t *noise) {
  * State: LONG_POLL - Start streaming MapRequest + process incremental updates
  * ========================================================================== */
 
-/* Send MapRequest with Stream=true to start long-poll on H2 stream 5 */
-static int do_start_long_poll(microlink_t *ml, ml_noise_state_t *noise) {
+/* Send MapRequest with Stream=true to start long-poll on H2 stream 5.
+ * omit_peers=false is for streaming_map_fetch: when the initial peer fetch
+ * is not done via Stream=false, the first stream message must carry the
+ * full netmap (Peers + DERPMap), so OmitPeers is dropped. */
+static int do_start_long_poll(microlink_t *ml, ml_noise_state_t *noise, bool omit_peers) {
     cJSON *root = cJSON_CreateObject();
     if (!root) return -1;
 
@@ -1901,7 +1919,11 @@ static int do_start_long_poll(microlink_t *ml, ml_noise_state_t *noise) {
     cJSON_AddBoolToObject(root, "Stream", true);
     cJSON_AddBoolToObject(root, "KeepAlive", true);
     cJSON_AddStringToObject(root, "Compress", "");    /* Disable compression */
-    cJSON_AddBoolToObject(root, "OmitPeers", true);   /* Already have peers */
+    /* omit_peers=true: peers were already fetched via Stream=false
+     * (existing path).
+     * omit_peers=false: streaming_map_fetch — receive all peers + DERPMap
+     * in the first stream message. */
+    cJSON_AddBoolToObject(root, "OmitPeers", omit_peers);
 
     /* NOTE: With Version >= 68, the control plane IGNORES Endpoints and
      * Hostinfo in Stream=true MapRequests. Endpoints are sent via separate
@@ -1940,6 +1962,217 @@ static int do_start_long_poll(microlink_t *ml, ml_noise_state_t *noise) {
     free(h2_buf);
 
     ESP_LOGI(TAG, "Streaming MapRequest sent on stream 5");
+    return 0;
+}
+
+/* For streaming_map_fetch: blockingly read the first MapResponse (the full
+ * netmap) on stream 5 opened by do_start_long_poll(omit_peers=false), and
+ * parse Node / Peers / DERPMap from it.
+ *
+ * headscale-based controllers such as ZTL do not respond to Stream=false
+ * MapRequests, so this function fetches the initial netmap instead of
+ * do_fetch_peers. A Stream=true response keeps the stream open and never
+ * sends END_STREAM, so do_fetch_peers' END_STREAM detection cannot be used.
+ * Instead, message completion is detected via the 4-byte length prefix at
+ * the start of each message (the Tailscale/headscale map stream framing).
+ *
+ * The DERP connect request must be issued only after this function
+ * succeeds — in the reverse order we would try to connect to DERP without
+ * a DERPMap and fail (same symptom as getting stuck with Stream=false). */
+static int do_read_initial_netmap(microlink_t *ml, ml_noise_state_t *noise) {
+    int64_t t_map_start = esp_timer_get_time();
+
+    uint8_t *h2_recv = ml_psram_malloc(ML_H2_BUFFER_SIZE);
+    if (!h2_recv) return -1;
+    size_t h2_total = 0;
+    size_t fpos = 0;              /* Consumed H2 frame boundary */
+
+    uint8_t *resp_buf = ml_psram_malloc(ML_JSON_BUFFER_SIZE);
+    if (!resp_buf) { free(h2_recv); return -1; }
+    size_t json_total = 0;        /* Accumulated DATA payload of stream 5 */
+
+    /* The initial netmap can be large, so wait up to 60 seconds (same as do_fetch_peers) */
+    struct timeval rcv_tv = { .tv_sec = 60, .tv_usec = 0 };
+    ml_setsockopt(ml->coord_sock, SOL_SOCKET, SO_RCVTIMEO, &rcv_tv, sizeof(rcv_tv));
+
+    uint64_t recv_start_ms = ml_get_time_ms();
+    uint64_t last_progress_ms = recv_start_ms;
+    size_t window_consumed = 0;
+
+    size_t msg_len = 0;           /* Body length from the length prefix (0 = not yet known) */
+    size_t msg_off = 0;           /* Body start offset (= prefix length) */
+    bool msg_complete = false;
+
+    for (int read_count = 0; read_count < 200 && !msg_complete; read_count++) {
+        uint8_t *frame_buf = ml_psram_malloc(65536);
+        if (!frame_buf) break;
+
+        int frame_len = noise_recv(ml, noise, frame_buf, 65536);
+        if (frame_len <= 0) {
+            free(frame_buf);
+            break;
+        }
+
+        if (h2_total + frame_len >= ML_H2_BUFFER_SIZE) {
+            ESP_LOGW(TAG, "H2 buffer full at %dKB, truncating", (int)(h2_total / 1024));
+            free(frame_buf);
+            break;
+        }
+        memcpy(h2_recv + h2_total, frame_buf, frame_len);
+        h2_total += frame_len;
+        window_consumed += frame_len;
+        free(frame_buf);
+
+        /* Consume only complete H2 frames, in order. An H2 frame can span
+         * multiple Noise frames, so keep the consumption boundary fpos and
+         * process incrementally. */
+        while (fpos + 9 <= h2_total) {
+            uint32_t f_len = (h2_recv[fpos] << 16) | (h2_recv[fpos + 1] << 8) | h2_recv[fpos + 2];
+            uint8_t f_type = h2_recv[fpos + 3];
+            uint8_t f_flags = h2_recv[fpos + 4];
+            uint32_t f_stream = ((h2_recv[fpos + 5] & 0x7F) << 24) |
+                                (h2_recv[fpos + 6] << 16) |
+                                (h2_recv[fpos + 7] << 8) | h2_recv[fpos + 8];
+            if (fpos + 9 + f_len > h2_total) break;  /* Frame tail has not arrived yet */
+
+            const uint8_t *payload = h2_recv + fpos + 9;
+
+            if (f_type == 0x00 && f_stream == 5 && f_len > 0) {
+                /* DATA on stream 5 = the MapResponse body */
+                if (json_total + f_len < ML_JSON_BUFFER_SIZE) {
+                    memcpy(resp_buf + json_total, payload, f_len);
+                    json_total += f_len;
+                }
+            } else if (f_type == 0x06 && f_len == 8 && !(f_flags & 0x01)) {
+                /* HTTP/2 PING from the server -> reply with PONG (ignoring it gets us disconnected) */
+                uint8_t pong[17];
+                pong[0] = 0x00; pong[1] = 0x00; pong[2] = 0x08;
+                pong[3] = 0x06; pong[4] = 0x01;
+                pong[5] = 0x00; pong[6] = 0x00; pong[7] = 0x00; pong[8] = 0x00;
+                memcpy(pong + 9, payload, 8);
+                noise_send(ml, noise, pong, sizeof(pong));
+            } else if (f_type == 0x04 && !(f_flags & 0x01)) {
+                /* HTTP/2 SETTINGS → ACK */
+                uint8_t settings_ack[9] = {0x00, 0x00, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00};
+                noise_send(ml, noise, settings_ack, sizeof(settings_ack));
+            }
+            /* Skip everything else (HEADERS etc.) */
+            fpos += 9 + f_len;
+        }
+
+        /* Message completion check: 4-byte length prefix at the start.
+         * Tailscale / headscale write it little-endian, but as a safeguard
+         * against implementation differences, try BE if the LE value is
+         * implausible; raw JSON without a prefix (starting with '{') is
+         * considered complete once it parses fully. */
+        if (json_total >= 4 && msg_len == 0 && resp_buf[0] != '{') {
+            size_t le = (size_t)resp_buf[0] | ((size_t)resp_buf[1] << 8) |
+                        ((size_t)resp_buf[2] << 16) | ((size_t)resp_buf[3] << 24);
+            size_t be = ((size_t)resp_buf[0] << 24) | ((size_t)resp_buf[1] << 16) |
+                        ((size_t)resp_buf[2] << 8) | (size_t)resp_buf[3];
+            if (le > 0 && le < ML_JSON_BUFFER_SIZE) {
+                msg_len = le;
+                msg_off = 4;
+            } else if (be > 0 && be < ML_JSON_BUFFER_SIZE) {
+                msg_len = be;
+                msg_off = 4;
+            }
+        }
+        if (msg_len > 0 && json_total >= msg_off + msg_len) {
+            msg_complete = true;
+            ESP_LOGI(TAG, "Initial netmap complete: %d bytes (%lums)",
+                     (int)msg_len, (unsigned long)(ml_get_time_ms() - recv_start_ms));
+        } else if (msg_len == 0 && json_total > 0 && resp_buf[0] == '{') {
+            resp_buf[json_total] = '\0';  /* Safe: accumulation is capped at SIZE-1 */
+            cJSON *probe = cJSON_Parse((char *)resp_buf);
+            if (probe) {
+                cJSON_Delete(probe);
+                msg_len = json_total;
+                msg_off = 0;
+                msg_complete = true;
+                ESP_LOGI(TAG, "Initial netmap complete (no length prefix): %d bytes",
+                         (int)msg_len);
+            }
+        }
+
+        uint64_t now = ml_get_time_ms();
+        if (!msg_complete && now - last_progress_ms > 5000) {
+            ESP_LOGI(TAG, "Initial netmap: received %dKB so far (%lums elapsed)",
+                     (int)(json_total / 1024), (unsigned long)(now - recv_start_ms));
+            last_progress_ms = now;
+        }
+
+        /* Every 32KB, replenish flow control with WINDOW_UPDATE (connection
+         * level + stream 5) so the server never stalls sending (same
+         * pattern as do_fetch_peers). */
+        if (window_consumed >= 32768) {
+            uint8_t wu_buf[26];
+            int wu_len = ml_h2_build_window_update(wu_buf, 13, 0, (uint32_t)window_consumed);
+            wu_len += ml_h2_build_window_update(wu_buf + wu_len, 13, 5, (uint32_t)window_consumed);
+            if (wu_len > 0) noise_send(ml, noise, wu_buf, wu_len);
+            window_consumed = 0;
+        }
+    }
+
+    /* Restore the normal recv timeout (5 seconds) */
+    rcv_tv.tv_sec = 5;
+    ml_setsockopt(ml->coord_sock, SOL_SOCKET, SO_RCVTIMEO, &rcv_tv, sizeof(rcv_tv));
+
+    free(h2_recv);
+
+    /* Replenish the remaining flow control. Stream 5 stays open (the
+     * long-poll continues), so always replenish the stream level as well,
+     * not just the connection level. */
+    if (window_consumed > 0) {
+        uint8_t wu_buf[26];
+        int wu_len = ml_h2_build_window_update(wu_buf, 13, 0, (uint32_t)window_consumed);
+        wu_len += ml_h2_build_window_update(wu_buf + wu_len, 13, 5, (uint32_t)window_consumed);
+        if (wu_len > 0) noise_send(ml, noise, wu_buf, wu_len);
+    }
+
+    if (!msg_complete || json_total == 0) {
+        ESP_LOGW(TAG, "Initial netmap not received (got %d bytes, complete=%d)",
+                 (int)json_total, msg_complete ? 1 : 0);
+        free(resp_buf);
+        return -1;
+    }
+
+    /* Parse the body (skipping the prefix). Even if a fragment of the next
+     * message is mixed in at the tail, we cut at msg_len so it is harmless.
+     * The next keepalive normally arrives 60 seconds later, so in practice
+     * a fragment almost never gets mixed in. */
+    char *parse_start = (char *)resp_buf + msg_off;
+    char saved = parse_start[msg_len];
+    parse_start[msg_len] = '\0';
+    cJSON *map_json = cJSON_Parse(parse_start);
+    parse_start[msg_len] = saved;
+
+    if (!map_json) {
+        const char *err = cJSON_GetErrorPtr();
+        ESP_LOGE(TAG, "Initial netmap JSON parse failed near: %.50s", err ? err : "unknown");
+        free(resp_buf);
+        return -1;
+    }
+
+    if (json_total > msg_off + msg_len) {
+        ESP_LOGD(TAG, "Initial netmap: %d trailing bytes discarded",
+                 (int)(json_total - msg_off - msg_len));
+    }
+
+    /* Ingest self-node info / peers / DERPMap (via the same shared parsers
+     * as do_fetch_peers — the DERP connection relies on the DERPMap being
+     * reliably parsed here). */
+    parse_self_node_from_map(ml, map_json);
+    parse_peers_from_map_response(ml, map_json);
+    parse_derp_map_from_map(ml, map_json);
+
+    cJSON_Delete(map_json);
+    free(resp_buf);
+
+    int64_t t_map_done = esp_timer_get_time();
+    ESP_LOGI(TAG, "[TIMING] Initial netmap recv+parse: %lld ms (%dKB)",
+             (t_map_done - t_map_start) / 1000, (int)(json_total / 1024));
+
     return 0;
 }
 
@@ -2190,6 +2423,14 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
 
         /* Parse peer updates */
         parse_peers_from_map_response(ml, update_json);
+
+        /* With streaming_map_fetch, DERPMap updates also arrive on this
+         * stream (the initial fetch uses the same stream), so ingest them.
+         * Behavior of the existing path (initial fetch via Stream=false) is
+         * unchanged. No-op for incremental updates without a DERPMap. */
+        if (ml->config.streaming_map_fetch) {
+            parse_derp_map_from_map(ml, update_json);
+        }
         cJSON_Delete(update_json);
     }
 
@@ -2335,11 +2576,30 @@ void ml_coord_task(void *arg) {
 
         case COORD_FETCH_PEERS:
             ESP_LOGI(TAG, "Fetching peers...");
-            if (do_fetch_peers(ml, &noise) < 0) {
-                ESP_LOGW(TAG, "MapRequest failed, will retry");
-                coord_close_conn(ml);
-                state = COORD_RECONNECTING;
-                break;
+            if (ml->config.streaming_map_fetch) {
+                /* headscale-based controllers such as ZTL do not respond to
+                 * Stream=false MapRequests (60s of zero bytes -> Empty
+                 * MapResponse -> reconnect loop). Like the official client,
+                 * start a single Stream=true / OmitPeers=false stream from
+                 * the beginning and take the full netmap (Peers + DERPMap)
+                 * from the first stream message. The DERP connect request is
+                 * issued after this point, once the DERPMap has been parsed
+                 * (in the reverse order we would try to connect to DERP
+                 * without a DERPMap and fail). */
+                if (do_start_long_poll(ml, &noise, false) < 0 ||
+                    do_read_initial_netmap(ml, &noise) < 0) {
+                    ESP_LOGW(TAG, "Streaming MapRequest failed, will retry");
+                    coord_close_conn(ml);
+                    state = COORD_RECONNECTING;
+                    break;
+                }
+            } else {
+                if (do_fetch_peers(ml, &noise) < 0) {
+                    ESP_LOGW(TAG, "MapRequest failed, will retry");
+                    coord_close_conn(ml);
+                    state = COORD_RECONNECTING;
+                    break;
+                }
             }
 
             xEventGroupSetBits(ml->events, ML_EVT_COORD_REGISTERED);
@@ -2353,9 +2613,15 @@ void ml_coord_task(void *arg) {
                                     pdFALSE, pdTRUE, pdMS_TO_TICKS(15000));
             }
 
-            /* Start streaming long-poll for incremental updates */
-            if (do_start_long_poll(ml, &noise) < 0) {
-                ESP_LOGW(TAG, "Failed to start long-poll (non-fatal)");
+            /* Start streaming long-poll for incremental updates.
+             * With streaming_map_fetch, the long-poll on stream 5 was
+             * already started for the initial fetch, so do not start it a
+             * second time (reusing the same stream ID would violate the H2
+             * protocol). */
+            if (!ml->config.streaming_map_fetch) {
+                if (do_start_long_poll(ml, &noise, true) < 0) {
+                    ESP_LOGW(TAG, "Failed to start long-poll (non-fatal)");
+                }
             }
 
             /* Send initial endpoint update if STUN already completed.

--- a/components/microlink/src/ml_coord.c
+++ b/components/microlink/src/ml_coord.c
@@ -85,11 +85,40 @@ static int hex_to_bytes(const char *hex, uint8_t *bytes, size_t max_len) {
  * TCP I/O helpers for coord socket (owned exclusively by this task)
  * ========================================================================== */
 
+/* Single read from the coord transport (recv() semantics).
+ * With CONFIG_ML_CTRL_TLS the Noise byte stream runs inside TLS records;
+ * timeouts still surface as -1/EAGAIN via the TLS BIO. */
+static int coord_raw_recv(microlink_t *ml, uint8_t *buf, size_t len) {
+#ifdef CONFIG_ML_CTRL_TLS
+    return ml_coord_tls_recv(ml, buf, len);
+#else
+    return ml_recv(ml->coord_sock, buf, len, 0);
+#endif
+}
+
+/* Close the coord connection (TLS session first, then the socket) */
+static void coord_close_conn(microlink_t *ml) {
+#ifdef CONFIG_ML_CTRL_TLS
+    ml_coord_tls_free(ml);
+#endif
+    if (ml->coord_sock >= 0) {
+        ml_close_sock(ml->coord_sock);
+        ml->coord_sock = -1;
+    }
+}
+
 static int coord_send(microlink_t *ml, const uint8_t *data, size_t len) {
     /* Set send timeout to prevent indefinite blocking (v1 uses MSG_DONTWAIT) */
     struct timeval snd_tv = { .tv_sec = 5, .tv_usec = 0 };
     ml_setsockopt(ml->coord_sock, SOL_SOCKET, SO_SNDTIMEO, &snd_tv, sizeof(snd_tv));
 
+#ifdef CONFIG_ML_CTRL_TLS
+    if (ml_coord_tls_send(ml, data, len) < 0) {
+        ESP_LOGE(TAG, "coord_send (TLS) failed: len=%d errno=%d", (int)len, errno);
+        return -1;
+    }
+    return 0;
+#else
     size_t sent = 0;
     while (sent < len) {
         int n = ml_send(ml->coord_sock, data + sent, len - sent, 0);
@@ -101,13 +130,14 @@ static int coord_send(microlink_t *ml, const uint8_t *data, size_t len) {
         sent += n;
     }
     return 0;
+#endif
 }
 
 static int coord_recv(microlink_t *ml, uint8_t *buf, size_t len) {
     size_t recvd = 0;
     int retries = 0;
     while (recvd < len) {
-        int n = ml_recv(ml->coord_sock, buf + recvd, len - recvd, 0);
+        int n = coord_raw_recv(ml, buf + recvd, len - recvd);
         if (n <= 0) {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
                 if (recvd == 0) {
@@ -227,7 +257,13 @@ static int do_tcp_connect(microlink_t *ml) {
     struct addrinfo hints = { .ai_family = AF_UNSPEC, .ai_socktype = SOCK_STREAM };
     struct addrinfo *res = NULL;
 
-    if (ml_getaddrinfo(CTRL_HOST(ml), "80", &hints, &res) != 0 || !res) {
+#ifdef CONFIG_ML_CTRL_TLS
+    const char *ctrl_port = "443";
+#else
+    const char *ctrl_port = "80";
+#endif
+
+    if (ml_getaddrinfo(CTRL_HOST(ml), ctrl_port, &hints, &res) != 0 || !res) {
         ESP_LOGE(TAG, "DNS resolve failed for %s", CTRL_HOST(ml));
         return -1;
     }
@@ -257,7 +293,7 @@ static int do_tcp_connect(microlink_t *ml) {
     ml_setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl));
     ml_setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt));
 
-    ESP_LOGI(TAG, "Connecting to %s:80...", CTRL_HOST(ml));
+    ESP_LOGI(TAG, "Connecting to %s:%s...", CTRL_HOST(ml), ctrl_port);
 
     if (ml_connect(sock, res->ai_addr, res->ai_addrlen) < 0) {
         ESP_LOGE(TAG, "TCP connect failed: %d", errno);
@@ -272,6 +308,17 @@ static int do_tcp_connect(microlink_t *ml) {
              (t_tcp - t_dns) / 1000, (t_tcp - t_start) / 1000);
 
     ml->coord_sock = sock;
+
+#ifdef CONFIG_ML_CTRL_TLS
+    if (ml_coord_tls_handshake(ml, CTRL_HOST(ml)) < 0) {
+        ml_close_sock(ml->coord_sock);
+        ml->coord_sock = -1;
+        return -1;
+    }
+    int64_t t_tls = esp_timer_get_time();
+    ESP_LOGI(TAG, "[TIMING] Control TLS handshake: %lld ms", (t_tls - t_tcp) / 1000);
+#endif
+
     return 0;
 }
 
@@ -286,10 +333,24 @@ static int s_server_extra_data_len = 0;
 static int do_noise_handshake(microlink_t *ml, ml_noise_state_t *noise) {
     int64_t t_noise_start = esp_timer_get_time();
 
-    /* Initialize Noise state with our machine key and Tailscale's server key */
+    /* Initialize Noise state with our machine key and the control plane's
+     * server key. CONFIG_ML_CTRL_NOISE_PUBKEY_HEX overrides the built-in
+     * Tailscale key for Headscale-compatible control planes (value comes
+     * from https://<control-host>/key?v=88 → "publicKey":"mkey:<hex>"). */
+    const uint8_t *server_key = NULL;
+#ifdef CONFIG_ML_CTRL_NOISE_PUBKEY_HEX
+    static uint8_t custom_server_key[32];
+    if (CONFIG_ML_CTRL_NOISE_PUBKEY_HEX[0] != '\0') {
+        if (hex_to_bytes(CONFIG_ML_CTRL_NOISE_PUBKEY_HEX, custom_server_key, 32) == 32) {
+            server_key = custom_server_key;
+        } else {
+            ESP_LOGE(TAG, "Invalid ML_CTRL_NOISE_PUBKEY_HEX (need 64 hex chars) — using built-in key");
+        }
+    }
+#endif
     ml_noise_init(noise,
                    ml->machine_private_key, ml->machine_public_key,
-                   NULL);  /* NULL = use default Tailscale server key */
+                   server_key);
 
     /* Build Noise message 1 (101 bytes) */
     uint8_t msg1[128];
@@ -334,7 +395,7 @@ static int do_noise_handshake(microlink_t *ml, ml_noise_state_t *noise) {
     uint8_t *resp = ml_psram_malloc(2048);
     if (!resp) return -1;
 
-    int total = ml_recv(ml->coord_sock, resp, 2047, 0);
+    int total = coord_raw_recv(ml, resp, 2047);
     if (total <= 0) {
         ESP_LOGE(TAG, "Handshake recv failed: %d (errno=%d)", total, errno);
         free(resp);
@@ -468,7 +529,7 @@ static int do_noise_handshake(microlink_t *ml, ml_noise_state_t *noise) {
 
         extra_data = ml_psram_malloc(1024);
         if (extra_data) {
-            int n = ml_recv(ml->coord_sock, extra_data, 1024, 0);
+            int n = coord_raw_recv(ml, extra_data, 1024);
             if (n > 0) {
                 extra_len = n;
                 ESP_LOGI(TAG, "Read %d bytes of proactive frames from socket", extra_len);
@@ -1987,13 +2048,20 @@ static int do_send_endpoint_update(microlink_t *ml, ml_noise_state_t *noise) {
 
 /* Try to read one incremental MapResponse update (non-blocking) */
 static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
-    /* Use select() to check if data is available before blocking in recv */
-    fd_set readfds;
-    FD_ZERO(&readfds);
-    FD_SET(ml->coord_sock, &readfds);
-    struct timeval tv = { .tv_sec = 0, .tv_usec = 50000 };  /* 50ms */
-    int sel = ml_select_fds(ml->coord_sock + 1, &readfds, NULL, NULL, &tv);
-    if (sel <= 0) return 0;  /* No data available or error */
+#ifdef CONFIG_ML_CTRL_TLS
+    /* Decrypted bytes may already sit in the TLS layer with nothing left
+     * on the socket — select() alone would miss them. */
+    if (ml_coord_tls_pending(ml) == 0)
+#endif
+    {
+        /* Use select() to check if data is available before blocking in recv */
+        fd_set readfds;
+        FD_ZERO(&readfds);
+        FD_SET(ml->coord_sock, &readfds);
+        struct timeval tv = { .tv_sec = 0, .tv_usec = 50000 };  /* 50ms */
+        int sel = ml_select_fds(ml->coord_sock + 1, &readfds, NULL, NULL, &tv);
+        if (sel <= 0) return 0;  /* No data available or error */
+    }
 
     /* Data available — set short recv timeout for partial frame safety */
     struct timeval tv_recv = { .tv_sec = 2, .tv_usec = 0 };
@@ -2166,10 +2234,7 @@ void ml_coord_task(void *arg) {
                 }
                 break;
             case ML_CMD_DISCONNECT:
-                if (ml->coord_sock >= 0) {
-                    ml_close_sock(ml->coord_sock);
-                    ml->coord_sock = -1;
-                }
+                coord_close_conn(ml);
                 state = COORD_IDLE;
                 ml->state = ML_STATE_IDLE;
                 break;
@@ -2233,8 +2298,7 @@ void ml_coord_task(void *arg) {
             ml->state = ML_STATE_REGISTERING;
             if (do_noise_handshake(ml, &noise) < 0) {
                 ESP_LOGE(TAG, "Noise handshake failed");
-                ml_close_sock(ml->coord_sock);
-                ml->coord_sock = -1;
+                coord_close_conn(ml);
                 state = COORD_RECONNECTING;
                 break;
             }
@@ -2248,8 +2312,7 @@ void ml_coord_task(void *arg) {
         case COORD_H2_PREFACE:
             if (do_h2_preface(ml, &noise) < 0) {
                 ESP_LOGE(TAG, "H2 preface failed");
-                ml_close_sock(ml->coord_sock);
-                ml->coord_sock = -1;
+                coord_close_conn(ml);
                 state = COORD_RECONNECTING;
                 break;
             }
@@ -2260,8 +2323,7 @@ void ml_coord_task(void *arg) {
             ESP_LOGI(TAG, "Registering...");
             if (do_register(ml, &noise) < 0) {
                 ESP_LOGE(TAG, "Registration failed");
-                ml_close_sock(ml->coord_sock);
-                ml->coord_sock = -1;
+                coord_close_conn(ml);
                 state = COORD_RECONNECTING;
                 break;
             }
@@ -2272,8 +2334,7 @@ void ml_coord_task(void *arg) {
             ESP_LOGI(TAG, "Fetching peers...");
             if (do_fetch_peers(ml, &noise) < 0) {
                 ESP_LOGW(TAG, "MapRequest failed, will retry");
-                ml_close_sock(ml->coord_sock);
-                ml->coord_sock = -1;
+                coord_close_conn(ml);
                 state = COORD_RECONNECTING;
                 break;
             }
@@ -2567,10 +2628,7 @@ void ml_coord_task(void *arg) {
                 reconnect_attempts++;
 
                 /* Close old connection */
-                if (ml->coord_sock >= 0) {
-                    ml_close_sock(ml->coord_sock);
-                    ml->coord_sock = -1;
-                }
+                coord_close_conn(ml);
 
                 /* Reset Noise state for fresh handshake */
                 memset(&noise, 0, sizeof(noise));
@@ -2582,10 +2640,7 @@ void ml_coord_task(void *arg) {
     }
 
     /* Cleanup */
-    if (ml->coord_sock >= 0) {
-        ml_close_sock(ml->coord_sock);
-        ml->coord_sock = -1;
-    }
+    coord_close_conn(ml);
     memset(&noise, 0, sizeof(noise));
 
     ESP_LOGI(TAG, "Coord task exiting");

--- a/components/microlink/src/ml_coord_tls.c
+++ b/components/microlink/src/ml_coord_tls.c
@@ -1,0 +1,154 @@
+/**
+ * @file ml_coord_tls.c
+ * @brief TLS transport for the coordination connection (CONFIG_ML_CTRL_TLS)
+ *
+ * Wraps the ts2021 Noise handshake in TLS on port 443 for control planes
+ * that only expose an HTTPS listener (e.g. Headscale behind a load
+ * balancer, such as Lolipop Zero Trust Link). The server certificate is
+ * not verified: the control plane is authenticated by the pinned Noise
+ * public key, the same trust model as Tailscale's plain port-80 transport
+ * (and the same choice ml_derp.c makes for DERP).
+ *
+ * All functions run on the coord task only — no locking needed.
+ */
+
+#include "sdkconfig.h"
+
+#ifdef CONFIG_ML_CTRL_TLS
+
+#include "microlink_internal.h"
+#include "esp_log.h"
+#include "mbedtls/error.h"
+#include "mbedtls/net_sockets.h"
+#include <errno.h>
+#include <string.h>
+
+static const char *TAG = "ml_coord_tls";
+
+/* BIO callbacks route through ml_send/ml_recv so the AT-socket backend
+ * keeps working. SO_RCVTIMEO/SO_SNDTIMEO on the socket provide timeouts;
+ * a timeout surfaces as WANT_READ/WANT_WRITE and propagates out of
+ * mbedtls_ssl_read/write, which ml_coord_tls_recv maps back to EAGAIN. */
+static int coord_bio_send(void *ctx, const unsigned char *buf, size_t len) {
+    int fd = *(int *)ctx;
+    int n = ml_send(fd, buf, len, 0);
+    if (n < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return MBEDTLS_ERR_SSL_WANT_WRITE;
+        return MBEDTLS_ERR_NET_SEND_FAILED;
+    }
+    return n;
+}
+
+static int coord_bio_recv(void *ctx, unsigned char *buf, size_t len) {
+    int fd = *(int *)ctx;
+    int n = ml_recv(fd, buf, len, 0);
+    if (n < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return MBEDTLS_ERR_SSL_WANT_READ;
+        return MBEDTLS_ERR_NET_RECV_FAILED;
+    }
+    if (n == 0) return MBEDTLS_ERR_NET_CONN_RESET;
+    return n;
+}
+
+int ml_coord_tls_handshake(microlink_t *ml, const char *hostname) {
+    ml_coord_tls_t *t = &ml->coord_tls;
+
+    mbedtls_ssl_init(&t->ssl);
+    mbedtls_ssl_config_init(&t->ssl_conf);
+    mbedtls_entropy_init(&t->entropy);
+    mbedtls_ctr_drbg_init(&t->ctr_drbg);
+
+    int ret = mbedtls_ctr_drbg_seed(&t->ctr_drbg, mbedtls_entropy_func,
+                                     &t->entropy, NULL, 0);
+    if (ret != 0) goto fail;
+
+    ret = mbedtls_ssl_config_defaults(&t->ssl_conf,
+                                       MBEDTLS_SSL_IS_CLIENT,
+                                       MBEDTLS_SSL_TRANSPORT_STREAM,
+                                       MBEDTLS_SSL_PRESET_DEFAULT);
+    if (ret != 0) goto fail;
+
+    mbedtls_ssl_conf_authmode(&t->ssl_conf, MBEDTLS_SSL_VERIFY_NONE);
+    mbedtls_ssl_conf_rng(&t->ssl_conf, mbedtls_ctr_drbg_random, &t->ctr_drbg);
+
+    ret = mbedtls_ssl_setup(&t->ssl, &t->ssl_conf);
+    if (ret != 0) goto fail;
+    ret = mbedtls_ssl_set_hostname(&t->ssl, hostname);
+    if (ret != 0) goto fail;
+
+    t->sockfd = ml->coord_sock;
+    mbedtls_ssl_set_bio(&t->ssl, &t->sockfd, coord_bio_send, coord_bio_recv, NULL);
+
+    while ((ret = mbedtls_ssl_handshake(&t->ssl)) != 0) {
+        if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+            continue;  /* Socket timeouts (10s) bound the total wait */
+        }
+        goto fail;
+    }
+
+    t->active = true;
+    ESP_LOGI(TAG, "TLS established with %s (suite: %s)",
+             hostname, mbedtls_ssl_get_ciphersuite(&t->ssl));
+    return 0;
+
+fail:
+    {
+        char err_buf[128];
+        mbedtls_strerror(ret, err_buf, sizeof(err_buf));
+        ESP_LOGE(TAG, "TLS handshake with %s failed: -0x%04x (%s)",
+                 hostname, (unsigned)-ret, err_buf);
+    }
+    ml_coord_tls_free(ml);
+    return -1;
+}
+
+int ml_coord_tls_send(microlink_t *ml, const uint8_t *data, size_t len) {
+    ml_coord_tls_t *t = &ml->coord_tls;
+    if (!t->active) { errno = ENOTCONN; return -1; }
+
+    size_t sent = 0;
+    while (sent < len) {
+        int n = mbedtls_ssl_write(&t->ssl, data + sent, len - sent);
+        if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE) {
+            errno = EAGAIN;
+            return -1;  /* SNDTIMEO expired mid-write: caller treats as failure */
+        }
+        if (n <= 0) { errno = EIO; return -1; }
+        sent += n;
+    }
+    return (int)len;
+}
+
+/* recv() semantics: >0 bytes read, 0 peer closed, -1 error (EAGAIN on timeout) */
+int ml_coord_tls_recv(microlink_t *ml, uint8_t *buf, size_t len) {
+    ml_coord_tls_t *t = &ml->coord_tls;
+    if (!t->active) { errno = ENOTCONN; return -1; }
+
+    int n = mbedtls_ssl_read(&t->ssl, buf, len);
+    if (n > 0) return n;
+    if (n == 0 || n == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) return 0;
+    if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE) {
+        errno = EAGAIN;
+        return -1;
+    }
+    errno = EIO;
+    return -1;
+}
+
+size_t ml_coord_tls_pending(microlink_t *ml) {
+    ml_coord_tls_t *t = &ml->coord_tls;
+    if (!t->active) return 0;
+    return mbedtls_ssl_get_bytes_avail(&t->ssl);
+}
+
+void ml_coord_tls_free(microlink_t *ml) {
+    ml_coord_tls_t *t = &ml->coord_tls;
+    mbedtls_ssl_free(&t->ssl);
+    mbedtls_ssl_config_free(&t->ssl_conf);
+    mbedtls_ctr_drbg_free(&t->ctr_drbg);
+    mbedtls_entropy_free(&t->entropy);
+    t->sockfd = -1;
+    t->active = false;
+}
+
+#endif /* CONFIG_ML_CTRL_TLS */

--- a/components/microlink/src/ml_derp.c
+++ b/components/microlink/src/ml_derp.c
@@ -38,36 +38,33 @@ static const char *TAG = "ml_derp";
 #define DERP_CONNECT_TIMEOUT_MS  10000
 
 /* ============================================================================
- * Custom BIO callbacks for non-blocking TLS I/O
+ * Custom BIO callbacks for TLS I/O
  *
- * These wrap lwIP recv/send with guaranteed timeout behavior.
- * We don't trust mbedtls_net_recv_timeout on lwIP because lwIP's select()
- * can sometimes block indefinitely on ESP32.
+ * These wrap the socket layer (ml_read_sock/ml_write_sock) so that both
+ * lwIP and AT socket backends work transparently.
+ *
+ * recv is provided as a blocking recv (f_recv). With the recv_timeout BIO
+ * (f_recv_timeout) combined with mbedtls_ssl_conf_read_timeout, the TLS 1.3
+ * handshake fails with MBEDTLS_ERR_SSL_BAD_INPUT_DATA (Bad input
+ * parameters), so we align with the scheme that already works on the
+ * control plane side (coord_bio_recv in ml_coord_tls.c). Timeouts are
+ * enforced by SO_RCVTIMEO on the socket; a timeout surfaces as EAGAIN ->
+ * MBEDTLS_ERR_SSL_WANT_READ.
  * ========================================================================== */
 
 /**
- * Custom recv with timeout for mbedtls BIO.
- * Uses SO_RCVTIMEO on the socket as the timeout mechanism (simpler than select).
- * Returns bytes read, or MBEDTLS_ERR_SSL_TIMEOUT, MBEDTLS_ERR_SSL_WANT_READ.
+ * Custom blocking recv for mbedtls BIO (f_recv signature, no timeout arg).
+ * SO_RCVTIMEO on the socket bounds the wait; a timeout surfaces as
+ * EAGAIN/EWOULDBLOCK which we map to MBEDTLS_ERR_SSL_WANT_READ.
  */
-static int ml_derp_bio_recv_timeout(void *ctx, unsigned char *buf, size_t len,
-                                      uint32_t timeout) {
+static int ml_derp_bio_recv(void *ctx, unsigned char *buf, size_t len) {
     int fd = *(int *)ctx;
     if (fd < 0) return MBEDTLS_ERR_NET_INVALID_CONTEXT;
-
-    /* Set SO_RCVTIMEO to the requested timeout.
-     * If timeout is 0 (mbedTLS default = "no timeout"), use 10s as a sane
-     * default to avoid indefinite blocking on AT sockets. */
-    uint32_t effective_timeout = (timeout > 0) ? timeout : DERP_CONNECT_TIMEOUT_MS;
-    struct timeval tv;
-    tv.tv_sec = effective_timeout / 1000;
-    tv.tv_usec = (effective_timeout % 1000) * 1000;
-    ml_setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
     int ret = (int)ml_read_sock(fd, buf, len);
     if (ret < 0) {
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            return MBEDTLS_ERR_SSL_TIMEOUT;
+            return MBEDTLS_ERR_SSL_WANT_READ;
         }
         if (errno == EPIPE || errno == ECONNRESET) {
             return MBEDTLS_ERR_NET_CONN_RESET;
@@ -76,6 +73,9 @@ static int ml_derp_bio_recv_timeout(void *ctx, unsigned char *buf, size_t len,
             return MBEDTLS_ERR_SSL_WANT_READ;
         }
         return MBEDTLS_ERR_NET_RECV_FAILED;
+    }
+    if (ret == 0) {
+        return MBEDTLS_ERR_NET_CONN_RESET;
     }
     return ret;
 }
@@ -101,6 +101,31 @@ static int ml_derp_bio_send(void *ctx, const unsigned char *buf, size_t len) {
         return MBEDTLS_ERR_NET_SEND_FAILED;
     }
     return ret;
+}
+
+/**
+ * Common cleanup for failure paths in ml_derp_connect() after TLS init.
+ *
+ * Previously we only closed the socket and never freed the mbedTLS
+ * contexts, leaking entropy/ctr_drbg/ssl_conf on every connection failure,
+ * and — for failures after a successful ssl_setup — the ~20KB TLS I/O
+ * buffers as well (internal RAM, since CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y).
+ * Combined with infinite retries, internal RAM shrank monotonically,
+ * making mbedtls_ssl_setup's ALLOC_FAILED -> handshake's Bad input
+ * parameters progressively worse on its own. So always free everything.
+ *
+ * mbedtls_*_free() zeroizes the structs after freeing, so a later
+ * ml_derp_disconnect() freeing the same contexts is not a double free.
+ */
+static void derp_tls_abort(microlink_t *ml, int sock) {
+    mbedtls_ssl_free(&ml->derp.ssl);
+    mbedtls_ssl_config_free(&ml->derp.ssl_conf);
+    mbedtls_ctr_drbg_free(&ml->derp.ctr_drbg);
+    mbedtls_entropy_free(&ml->derp.entropy);
+    if (sock >= 0) {
+        ml_close_sock(sock);
+    }
+    ml->derp.sockfd = -1;
 }
 
 /* DERP frame types */
@@ -343,7 +368,8 @@ static void dispatch_derp_frame(microlink_t *ml, uint8_t frame_type,
 
 /**
  * Try to read one DERP frame.
- * Uses mbedtls recv_timeout (100ms) so ssl_read never blocks indefinitely.
+ * SO_RCVTIMEO on the socket bounds each read, so ssl_read never blocks
+ * indefinitely (timeout surfaces as WANT_READ from the blocking-recv BIO).
  * Returns: 1 = frame read and dispatched, 0 = timeout (no data), <0 = error
  */
 static int poll_derp_read(microlink_t *ml) {
@@ -645,6 +671,9 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
      * NOT on connection failure (to avoid bouncing between nodes). */
     const char *derp_host = ML_DERP_HOST;
     int derp_port = ML_DERP_PORT;
+    /* Track the region actually used, for logging (differs from HomeDERP on fallback) */
+    uint16_t derp_region_used = ml->derp_home_region ? ml->derp_home_region : ML_DERP_REGION;
+    bool node_selected = false;
 
     if (ml->derp_region_count > 0 && ml->derp_home_region > 0) {
         for (int i = 0; i < ml->derp_region_count; i++) {
@@ -658,6 +687,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
                         if (ml->derp_regions[i].nodes[attempt].derp_port > 0) {
                             derp_port = ml->derp_regions[i].nodes[attempt].derp_port;
                         }
+                        node_selected = true;
                         break;
                     }
                 }
@@ -666,10 +696,39 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
         }
     }
 
+    /* Fallback for when HomeDERP is not present in the DERPMap.
+     * With headscale-based controllers (e.g. ZTL), HomeDERP may still point
+     * at an official Tailscale region (e.g. 9) while the DERPMap only
+     * contains their own region (e.g. 900). Falling back to the default
+     * ML_DERP_HOST (official) in that case is a dead end — neither auth nor
+     * TLS succeeds against the official DERP — so instead pick the first
+     * usable node (not avoid, not stun-only, has a hostname) from the
+     * DERPMap the controller handed out. In the normal official-Tailscale
+     * case, HomeDERP is in the DERPMap so node_selected is set and this
+     * branch is never taken; behavior is unchanged. */
+    if (!node_selected && ml->derp_region_count > 0) {
+        for (int i = 0; i < ml->derp_region_count && !node_selected; i++) {
+            ml_derp_region_t *r = &ml->derp_regions[i];
+            if (r->avoid) continue;
+            for (int j = 0; j < r->node_count; j++) {
+                if (!r->nodes[j].stun_only && r->nodes[j].hostname[0]) {
+                    derp_host = r->nodes[j].hostname;
+                    derp_port = (r->nodes[j].derp_port > 0) ? r->nodes[j].derp_port
+                                                            : ML_DERP_PORT;
+                    derp_region_used = r->region_id;
+                    node_selected = true;
+                    ESP_LOGW(TAG, "Home DERP region %d not in DERPMap, falling back to region %d (%s)",
+                             ml->derp_home_region, derp_region_used, derp_host);
+                    break;
+                }
+            }
+        }
+    }
+
     int64_t t_derp_start = esp_timer_get_time();
 
     ESP_LOGI(TAG, "Connecting to DERP %s:%d (region %d)",
-             derp_host, derp_port, ml->derp_home_region ? ml->derp_home_region : ML_DERP_REGION);
+             derp_host, derp_port, derp_region_used);
 
     /* DNS resolve — accept IPv4 or IPv6 (carrier may be IPv6-only) */
     struct addrinfo hints = { .ai_family = AF_UNSPEC, .ai_socktype = SOCK_STREAM };
@@ -714,26 +773,67 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
     mbedtls_entropy_init(&ml->derp.entropy);
     mbedtls_ctr_drbg_init(&ml->derp.ctr_drbg);
 
-    mbedtls_ctr_drbg_seed(&ml->derp.ctr_drbg, mbedtls_entropy_func,
+    /* Always check the return values of the mbedTLS setup functions and
+     * abort immediately on failure instead of proceeding to the handshake.
+     * On failure (typically ALLOC_FAILED), mbedtls_ssl_setup resets
+     * ssl->conf to NULL in its error label, so ignoring the error and
+     * proceeding to the handshake trips the sanity check with
+     * MBEDTLS_ERR_SSL_BAD_INPUT_DATA — misreported as "Bad input
+     * parameters" when the real cause is out-of-memory. */
+    int cfg_ret;
+    cfg_ret = mbedtls_ctr_drbg_seed(&ml->derp.ctr_drbg, mbedtls_entropy_func,
                            &ml->derp.entropy, NULL, 0);
+    if (cfg_ret != 0) {
+        ESP_LOGE(TAG, "ctr_drbg_seed failed: -0x%04x", -cfg_ret);
+        derp_tls_abort(ml, sock);
+        return ESP_FAIL;
+    }
 
-    mbedtls_ssl_config_defaults(&ml->derp.ssl_conf,
+    cfg_ret = mbedtls_ssl_config_defaults(&ml->derp.ssl_conf,
                                  MBEDTLS_SSL_IS_CLIENT,
                                  MBEDTLS_SSL_TRANSPORT_STREAM,
                                  MBEDTLS_SSL_PRESET_DEFAULT);
+    if (cfg_ret != 0) {
+        ESP_LOGE(TAG, "ssl_config_defaults failed: -0x%04x", -cfg_ret);
+        derp_tls_abort(ml, sock);
+        return ESP_FAIL;
+    }
     mbedtls_ssl_conf_authmode(&ml->derp.ssl_conf, MBEDTLS_SSL_VERIFY_NONE);
     mbedtls_ssl_conf_rng(&ml->derp.ssl_conf, mbedtls_ctr_drbg_random, &ml->derp.ctr_drbg);
-    mbedtls_ssl_conf_read_timeout(&ml->derp.ssl_conf, DERP_CONNECT_TIMEOUT_MS);
+    /* Pin the DERP connection to TLS 1.2. When the DERP relay uses a
+     * Let's Encrypt ECDSA certificate, the ESP-IDF mbedTLS TLS 1.3 path
+     * cannot interpret the certificate's signature algorithm OID and fails
+     * with "X509 - Signature algorithm (oid) is unsupported" (even with
+     * authmode=VERIFY_NONE, TLS 1.3 cannot skip certificate processing).
+     * DERP also accepts TLS 1.2, so pin to 1.2 to bypass the 1.3
+     * certificate path. */
+    mbedtls_ssl_conf_max_tls_version(&ml->derp.ssl_conf, MBEDTLS_SSL_VERSION_TLS1_2);
 
-    mbedtls_ssl_setup(&ml->derp.ssl, &ml->derp.ssl_conf);
-    mbedtls_ssl_set_hostname(&ml->derp.ssl, derp_host);
+    cfg_ret = mbedtls_ssl_setup(&ml->derp.ssl, &ml->derp.ssl_conf);
+    if (cfg_ret != 0) {
+        /* -0x7F00 (ALLOC_FAILED) means internal RAM exhaustion. To allocate
+         * the ~20KB TLS I/O buffers from PSRAM instead, set
+         * CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y. */
+        ESP_LOGE(TAG, "mbedtls_ssl_setup failed: -0x%04x", -cfg_ret);
+        derp_tls_abort(ml, sock);
+        return ESP_FAIL;
+    }
+    cfg_ret = mbedtls_ssl_set_hostname(&ml->derp.ssl, derp_host);
+    if (cfg_ret != 0) {
+        ESP_LOGE(TAG, "ssl_set_hostname failed: -0x%04x", -cfg_ret);
+        derp_tls_abort(ml, sock);
+        return ESP_FAIL;
+    }
     /* Store socket fd BEFORE setting bio.
      * Use custom BIO callbacks that route through ml_read_sock/ml_write_sock,
      * which transparently support both lwIP and AT socket backends.
      * Timeout is handled via SO_RCVTIMEO. */
     ml->derp.sockfd = sock;
+    /* Pass a blocking recv as f_recv and set f_recv_timeout to NULL
+     * (same scheme as the control plane; avoids the TLS 1.3 Bad input
+     * data failure). */
     mbedtls_ssl_set_bio(&ml->derp.ssl, &ml->derp.sockfd,
-                         ml_derp_bio_send, NULL, ml_derp_bio_recv_timeout);
+                         ml_derp_bio_send, ml_derp_bio_recv, NULL);
 
     /* TLS handshake - socket has 10s SO_RCVTIMEO from connect phase. */
     int ret;
@@ -744,8 +844,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
         char err_buf[128];
         mbedtls_strerror(ret, err_buf, sizeof(err_buf));
         ESP_LOGE(TAG, "TLS handshake failed: %s", err_buf);
-        ml_close_sock(sock);
-        ml->derp.sockfd = -1;
+        derp_tls_abort(ml, sock);
         return ESP_FAIL;
     }
 
@@ -766,8 +865,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
     ret = mbedtls_ssl_write(&ml->derp.ssl, (const uint8_t *)upgrade_req, strlen(upgrade_req));
     if (ret < 0) {
         ESP_LOGE(TAG, "Failed to send HTTP upgrade");
-        ml_close_sock(sock);
-        ml->derp.sockfd = -1;
+        derp_tls_abort(ml, sock);
         return ESP_FAIL;
     }
 
@@ -782,8 +880,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
         while (resp_len < (int)sizeof(resp_buf) - 1) {
             if (ml_get_time_ms() - http_start > DERP_CONNECT_TIMEOUT_MS) {
                 ESP_LOGE(TAG, "HTTP upgrade response timeout");
-                ml_close_sock(sock);
-                ml->derp.sockfd = -1;
+                derp_tls_abort(ml, sock);
                 return ESP_FAIL;
             }
 
@@ -795,14 +892,12 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
                     continue;
                 }
                 ESP_LOGE(TAG, "HTTP upgrade read failed: -0x%04x", -ret);
-                ml_close_sock(sock);
-                ml->derp.sockfd = -1;
+                derp_tls_abort(ml, sock);
                 return ESP_FAIL;
             }
             if (ret == 0) {
                 ESP_LOGE(TAG, "Connection closed during HTTP upgrade");
-                ml_close_sock(sock);
-                ml->derp.sockfd = -1;
+                derp_tls_abort(ml, sock);
                 return ESP_FAIL;
             }
             resp_len++;
@@ -820,8 +915,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
 
         if (!found_end || strstr((char *)resp_buf, "101") == NULL) {
             ESP_LOGE(TAG, "DERP upgrade rejected: %.100s", resp_buf);
-            ml_close_sock(sock);
-            ml->derp.sockfd = -1;
+            derp_tls_abort(ml, sock);
             return ESP_FAIL;
         }
         ESP_LOGI(TAG, "HTTP 101 Switching Protocols received");
@@ -851,16 +945,14 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
     esp_err_t err = derp_recv_frame_header(ml, &frame_type, &frame_len, DERP_CONNECT_TIMEOUT_MS);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to read ServerKey frame header (err=%d)", err);
-        ml_close_sock(sock);
-        ml->derp.sockfd = -1;
+        derp_tls_abort(ml, sock);
         return ESP_FAIL;
     }
 
     if (frame_type != DERP_FRAME_SERVER_KEY || frame_len < 40) {
         ESP_LOGE(TAG, "Expected ServerKey frame (0x01), got 0x%02x len=%lu",
                  frame_type, (unsigned long)frame_len);
-        ml_close_sock(sock);
-        ml->derp.sockfd = -1;
+        derp_tls_abort(ml, sock);
         return ESP_FAIL;
     }
 
@@ -869,8 +961,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
     static const uint8_t DERP_MAGIC[8] = {0x44, 0x45, 0x52, 0x50, 0xf0, 0x9f, 0x94, 0x91};
     if (derp_tls_read_all(ml, magic, 8, DERP_CONNECT_TIMEOUT_MS) < 0) {
         ESP_LOGE(TAG, "Failed to read ServerKey magic");
-        ml_close_sock(sock);
-        ml->derp.sockfd = -1;
+        derp_tls_abort(ml, sock);
         return ESP_FAIL;
     }
 
@@ -878,8 +969,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
         ESP_LOGE(TAG, "Invalid DERP magic: %02x%02x%02x%02x%02x%02x%02x%02x",
                  magic[0], magic[1], magic[2], magic[3],
                  magic[4], magic[5], magic[6], magic[7]);
-        ml_close_sock(sock);
-        ml->derp.sockfd = -1;
+        derp_tls_abort(ml, sock);
         return ESP_FAIL;
     }
     ESP_LOGI(TAG, "DERP magic verified");
@@ -888,8 +978,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
     uint8_t derp_server_key[32];
     if (derp_tls_read_all(ml, derp_server_key, 32, DERP_CONNECT_TIMEOUT_MS) < 0) {
         ESP_LOGE(TAG, "Failed to read server key");
-        ml_close_sock(sock);
-        ml->derp.sockfd = -1;
+        derp_tls_abort(ml, sock);
         return ESP_FAIL;
     }
 
@@ -922,8 +1011,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
         size_t ciphertext_len = json_len + NACL_BOX_MACBYTES;
         uint8_t *ciphertext = malloc(ciphertext_len);
         if (!ciphertext) {
-            ml_close_sock(sock);
-            ml->derp.sockfd = -1;
+            derp_tls_abort(ml, sock);
             return ESP_FAIL;
         }
 
@@ -935,8 +1023,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
                      ) != 0) {
             ESP_LOGE(TAG, "NaCl box encrypt failed");
             free(ciphertext);
-            ml_close_sock(sock);
-            ml->derp.sockfd = -1;
+            derp_tls_abort(ml, sock);
             return ESP_FAIL;
         }
 
@@ -945,8 +1032,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
         uint8_t *ci_payload = malloc(ci_payload_len);
         if (!ci_payload) {
             free(ciphertext);
-            ml_close_sock(sock);
-            ml->derp.sockfd = -1;
+            derp_tls_abort(ml, sock);
             return ESP_FAIL;
         }
 
@@ -965,8 +1051,7 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
         if (derp_write_frame(ml, DERP_FRAME_CLIENT_INFO, ci_payload, ci_payload_len) < 0) {
             ESP_LOGE(TAG, "Failed to send ClientInfo");
             free(ci_payload);
-            ml_close_sock(sock);
-            ml->derp.sockfd = -1;
+            derp_tls_abort(ml, sock);
             return ESP_FAIL;
         }
         free(ci_payload);
@@ -999,11 +1084,14 @@ esp_err_t ml_derp_connect(microlink_t *ml) {
     }
 
     /* Switch socket to short timeout for data phase.
-     * Long timeout was needed for TLS handshake, but polling must be fast. */
+     * Long timeout was needed for TLS handshake, but polling must be fast.
+     * conf_read_timeout is deliberately not called: recv uses the f_recv
+     * (blocking) scheme, so only SO_RCVTIMEO takes effect (with
+     * f_recv_timeout unused, conf_read_timeout would be a no-op; same
+     * policy as the TLS 1.3 Bad input data workaround). */
     {
         struct timeval tv = { .tv_sec = 0, .tv_usec = 200000 };  /* 200ms */
         ml_setsockopt(ml->derp.sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-        mbedtls_ssl_conf_read_timeout(&ml->derp.ssl_conf, 200);
     }
 
     ml->derp.connected = true;


### PR DESCRIPTION
## Summary

This PR makes MicroLink actually connect to a custom, non-Tailscale control plane end-to-end. It started as "build-time control plane config + TLS control transport" and grew, through bringing up a real ESP32 node on a [headscale](https://github.com/juanfont/headscale)-based deployment (Lolipop Zero Trust Link), to cover the three further places where MicroLink assumed Tailscale's SaaS: the initial map poll, DERP region selection, and DERP TLS.

The README documents Headscale/Ionscale support, but several parts were hardcoded to Tailscale (control host + Noise key, the Stream=false initial fetch, DERP region 9 / derp9e.tailscale.com). Each commit is independent and defaults to current behavior.

## Commits

1. **Build-time custom control plane config with TLS transport**
   `CONFIG_ML_CTRL_HOST`, and `CONFIG_ML_CTRL_TLS` to wrap the ts2021 Noise handshake in TLS on port 443 (new `ml_coord_tls.c`) for control planes exposed only over HTTPS. Cert not verified; the control plane is authenticated by the pinned Noise key, same trust model as the plain port-80 transport.

2. **`ctrl_host` / `ctrl_noise_pubkey` in `microlink_config_t`**
   Runtime counterparts, so the host and its `/key`-fetched Noise key can be provisioned on-device rather than baked in.

3. **`streaming_map_fetch` for controllers that ignore Stream=false**
   Some headscale control planes never respond to the initial Stream=false MapRequest (60s of zero bytes → empty MapResponse → reconnect loop). The native client starts a single Stream=true poll whose first message carries the full netmap. New flag (default false) switches to that: start long-poll with OmitPeers=false, read the initial netmap, parse Node/Peers/DERPMap, then connect DERP. Parsing is factored into shared helpers used by both paths.

4. **DERP connection for custom control planes** — three fixes:
   - **Region fallback**: if the server's HomeDERP region isn't in the DERPMap (custom planes advertise their own region IDs), use the first available region instead of dialing the hardcoded `derp9e.tailscale.com`.
   - **Robust TLS setup + no leak**: check every mbedTLS setup return and abort before `mbedtls_ssl_handshake`. A failing `mbedtls_ssl_setup` (typically `-0x7F00` ALLOC_FAILED under internal-RAM pressure) NULLs `ssl->conf`, so handshake then returned `BAD_INPUT_DATA` and the real cause (OOM) showed up as "Bad input parameters". Added `derp_tls_abort()` to free the mbedTLS context (~20KB TLS buffers) on every failure path; the old code only closed the socket and leaked per retry. (App-side companion: `CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y` to place TLS buffers in PSRAM.)
   - **Pin DERP TLS to 1.2**: on ESP-IDF mbedTLS the TLS 1.3 path can't parse an ECDSA cert's signature-algorithm OID even with `VERIFY_NONE` (TLS 1.3 can't skip cert processing). DERP relays accept TLS 1.2, so cap max version at 1.2.

## Testing

Brought up an ESP32-S3 node on a headscale-based control plane (443/TLS-only, DERP relays behind Let's Encrypt ECDSA certs): control TLS + Noise + registration + streaming netmap + DERP TLS + relay handshake all succeed, node shows online, and packets flow (rx/tx increasing). All commits build on ESP-IDF v5.4 / esp32s3.

With every new option off / `streaming_map_fetch=false`, behavior against Tailscale's SaaS is unchanged.